### PR TITLE
LPFG-663: Add auditing to Learning Catalogue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,10 @@ services:
       - 9200:9200
       - 9300:9300
     command: "elasticsearch -E cluster.name=local -E discovery.type=single-node"
+
+  elastichq:
+    image: elastichq/elasticsearch-hq
+    ports:
+      - 5000:5000
+    environment:
+      HQ_DEFAULT_URL: http://elasticsearch:9200

--- a/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
@@ -11,6 +11,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.cslearning.catalogue.domain.Course;
 import uk.gov.cslearning.catalogue.domain.Resource;
 import uk.gov.cslearning.catalogue.domain.module.Module;
+import uk.gov.cslearning.catalogue.repository.AuditableCourseRepository;
 import uk.gov.cslearning.catalogue.repository.CourseRepository;
 import uk.gov.cslearning.catalogue.repository.ResourceRepository;
 import uk.gov.cslearning.catalogue.service.ModuleService;
@@ -31,14 +32,14 @@ public class CourseController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CourseController.class);
 
-    private final CourseRepository courseRepository;
+    private final AuditableCourseRepository courseRepository;
 
     private final ResourceRepository resourceRepository;
 
     private final ModuleService moduleService;
 
     @Autowired
-    public CourseController(CourseRepository courseRepository, ResourceRepository resourceRepository, ModuleService moduleService) {
+    public CourseController(AuditableCourseRepository courseRepository, ResourceRepository resourceRepository, ModuleService moduleService) {
         this.courseRepository = courseRepository;
         this.resourceRepository = resourceRepository;
         this.moduleService = moduleService;

--- a/src/main/java/uk/gov/cslearning/catalogue/api/LearningProviderController.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/api/LearningProviderController.java
@@ -11,7 +11,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.cslearning.catalogue.domain.CancellationPolicy;
 import uk.gov.cslearning.catalogue.domain.LearningProvider;
 import uk.gov.cslearning.catalogue.domain.TermsAndConditions;
-import uk.gov.cslearning.catalogue.repository.LearningProviderRepository;
+import uk.gov.cslearning.catalogue.repository.AuditableLearningProviderRepository;
 
 import java.util.Optional;
 
@@ -23,10 +23,10 @@ import static org.springframework.http.HttpStatus.OK;
 public class LearningProviderController {
     private static final Logger LOGGER = LoggerFactory.getLogger(LearningProviderController.class);
 
-    private final LearningProviderRepository learningProviderRepository;
+    private final AuditableLearningProviderRepository learningProviderRepository;
 
     @Autowired
-    public LearningProviderController(LearningProviderRepository learningProviderRepository) {
+    public LearningProviderController(AuditableLearningProviderRepository learningProviderRepository) {
         this.learningProviderRepository = learningProviderRepository;
     }
 

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/Auditable.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/Auditable.java
@@ -1,0 +1,42 @@
+package uk.gov.cslearning.catalogue.domain;
+
+public abstract class Auditable {
+    private long createdDate;
+    private String createdBy;
+    private long modifiedDate;
+    private String modifiedBy;
+
+    public abstract String getId();
+
+    public long getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(long createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public long getModifiedDate() {
+        return modifiedDate;
+    }
+
+    public void setModifiedDate(long modifiedDate) {
+        this.modifiedDate = modifiedDate;
+    }
+
+    public String getModifiedBy() {
+        return modifiedBy;
+    }
+
+    public void setModifiedBy(String modifiedBy) {
+        this.modifiedBy = modifiedBy;
+    }
+}

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/Course.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/Course.java
@@ -18,7 +18,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableSet;
 
 @Document(indexName = "lpg-courses-0.3.0", type = "course")
-public class Course {
+public class Course extends Auditable {
 
     @Id
     private String id = UUIDs.randomBase64UUID();

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/LearningProvider.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/LearningProvider.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Document(indexName = "lpg-learning-providers", type = "learningProvider")
-public class LearningProvider {
+public class LearningProvider extends Auditable {
 
     @Id
     private String id = UUIDs.randomBase64UUID();

--- a/src/main/java/uk/gov/cslearning/catalogue/repository/AuditableCourseRepository.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/AuditableCourseRepository.java
@@ -1,0 +1,25 @@
+package uk.gov.cslearning.catalogue.repository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import uk.gov.cslearning.catalogue.domain.Course;
+import uk.gov.cslearning.catalogue.service.AuthenticationFacade;
+
+@Repository
+public class AuditableCourseRepository extends AuditableRepository<Course, CourseRepository> {
+
+    @Autowired
+    public AuditableCourseRepository(CourseRepository wrappedRepository, AuthenticationFacade authenticationFacade) {
+        super(wrappedRepository, authenticationFacade);
+    }
+
+    public Page<Course> findMandatory(String department, Pageable pageRequest) {
+        return super.wrappedRepository.findMandatory(department, pageRequest);
+    }
+
+    public Page<Course> findSuggested(String department, String areaOfWork, String interest, Pageable pageable) {
+        return super.wrappedRepository.findSuggested(department, areaOfWork, interest, pageable);
+    }
+}

--- a/src/main/java/uk/gov/cslearning/catalogue/repository/AuditableLearningProviderRepository.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/AuditableLearningProviderRepository.java
@@ -1,0 +1,12 @@
+package uk.gov.cslearning.catalogue.repository;
+
+import org.springframework.stereotype.Repository;
+import uk.gov.cslearning.catalogue.domain.LearningProvider;
+import uk.gov.cslearning.catalogue.service.AuthenticationFacade;
+
+@Repository
+public class AuditableLearningProviderRepository extends AuditableRepository<LearningProvider, LearningProviderRepository> {
+    public AuditableLearningProviderRepository(LearningProviderRepository wrappedRepository, AuthenticationFacade authenticationFacade) {
+        super(wrappedRepository, authenticationFacade);
+    }
+}

--- a/src/main/java/uk/gov/cslearning/catalogue/repository/AuditableRepository.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/AuditableRepository.java
@@ -1,0 +1,145 @@
+package uk.gov.cslearning.catalogue.repository;
+
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.core.query.SearchQuery;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import uk.gov.cslearning.catalogue.domain.Auditable;
+import uk.gov.cslearning.catalogue.service.AuthenticationFacade;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public abstract class AuditableRepository <T extends Auditable, R extends ElasticsearchRepository<T, String>> implements ElasticsearchRepository<T, String> {
+
+    protected final R wrappedRepository;
+    private final AuthenticationFacade authenticationFacade;
+
+    public AuditableRepository(R wrappedRepository, AuthenticationFacade authenticationFacade) {
+        this.wrappedRepository = wrappedRepository;
+        this.authenticationFacade = authenticationFacade;
+    }
+
+    @Override
+    public <S extends T> S save(S entity) {
+
+        Optional<T> existingEntityOptional = this.wrappedRepository.findById(entity.getId());
+
+        if (existingEntityOptional.isPresent()) {
+            T existingEntity = existingEntityOptional.get();
+
+            entity.setCreatedDate(existingEntity.getCreatedDate());
+            entity.setCreatedBy(existingEntity.getCreatedBy());
+            entity.setModifiedBy(authenticationFacade.getAuthentication().getName());
+            entity.setModifiedDate(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
+        } else {
+            entity.setCreatedBy(authenticationFacade.getAuthentication().getName());
+            entity.setCreatedDate(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
+        }
+
+        return this.wrappedRepository.save(entity);
+    }
+
+
+    @Override
+    public <S extends T> Iterable<S> saveAll(Iterable<S> entities) {
+        return StreamSupport.stream(entities.spliterator(), false).map(this::save).collect(Collectors.toList());
+    }
+
+    @Override
+    public <S extends T> S index(S entity) {
+        return this.wrappedRepository.index(entity);
+    }
+
+    @Override
+    public Iterable<T> search(QueryBuilder query) {
+        return this.wrappedRepository.search(query);
+    }
+
+    @Override
+    public Page<T> search(QueryBuilder query, Pageable pageable) {
+        return this.wrappedRepository.search(query, pageable);
+    }
+
+    @Override
+    public Page<T> search(SearchQuery searchQuery) {
+        return this.wrappedRepository.search(searchQuery);
+    }
+
+    @Override
+    public Page<T> searchSimilar(T entity, String[] fields, Pageable pageable) {
+        return this.wrappedRepository.searchSimilar(entity, fields, pageable);
+    }
+
+    @Override
+    public void refresh() {
+        this.wrappedRepository.refresh();
+    }
+
+    @Override
+    public Class<T> getEntityClass() {
+        return this.wrappedRepository.getEntityClass();
+    }
+
+    @Override
+    public Iterable<T> findAll(Sort sort) {
+        return this.wrappedRepository.findAll(sort);
+    }
+
+    @Override
+    public Page<T> findAll(Pageable pageable) {
+        return this.wrappedRepository.findAll(pageable);
+    }
+
+    @Override
+    public Optional<T> findById(String s) {
+        return this.wrappedRepository.findById(s);
+    }
+
+    @Override
+    public boolean existsById(String s) {
+        return this.wrappedRepository.existsById(s);
+    }
+
+    @Override
+    public Iterable<T> findAll() {
+        return this.wrappedRepository.findAll();
+    }
+
+    @Override
+    public Iterable<T> findAllById(Iterable<String> strings) {
+        return wrappedRepository.findAllById(strings);
+    }
+
+    @Override
+    public long count() {
+        return this.wrappedRepository.count();
+    }
+
+    @Override
+    public void deleteById(String s) {
+        this.wrappedRepository.deleteById(s);
+    }
+
+    @Override
+    public void delete(T entity) {
+        this.wrappedRepository.delete(entity);
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends T> entities) {
+        this.wrappedRepository.deleteAll(entities);
+    }
+
+    @Override
+    public void deleteAll() {
+        this.wrappedRepository.deleteAll();
+    }
+}

--- a/src/main/java/uk/gov/cslearning/catalogue/repository/AuditableRepository.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/AuditableRepository.java
@@ -11,9 +11,8 @@ import uk.gov.cslearning.catalogue.domain.Auditable;
 import uk.gov.cslearning.catalogue.service.AuthenticationFacade;
 
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.util.Optional;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -38,10 +37,10 @@ public abstract class AuditableRepository <T extends Auditable, R extends Elasti
             entity.setCreatedDate(existingEntity.getCreatedDate());
             entity.setCreatedBy(existingEntity.getCreatedBy());
             entity.setModifiedBy(authenticationFacade.getAuthentication().getName());
-            entity.setModifiedDate(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
+            entity.setModifiedDate(LocalDateTime.now().atZone(ZoneId.systemDefault()).toEpochSecond());
         } else {
             entity.setCreatedBy(authenticationFacade.getAuthentication().getName());
-            entity.setCreatedDate(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
+            entity.setCreatedDate(LocalDateTime.now().atZone(ZoneId.systemDefault()).toEpochSecond());
         }
 
         return this.wrappedRepository.save(entity);

--- a/src/main/java/uk/gov/cslearning/catalogue/repository/CourseRepository.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/CourseRepository.java
@@ -7,10 +7,11 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 import org.springframework.stereotype.Repository;
 import uk.gov.cslearning.catalogue.api.FilterParameters;
 import uk.gov.cslearning.catalogue.domain.Course;
+import uk.gov.cslearning.catalogue.domain.LearningProvider;
 import uk.gov.cslearning.catalogue.domain.SearchPage;
 
 @Repository
-public interface CourseRepository extends ElasticsearchRepository<Course, String>, ResourceSearchRepository{
+public interface CourseRepository extends ElasticsearchRepository<Course, String>, ResourceSearchRepository {
 
     @Query("{ \"bool\": { \"must\": [{ \"match\": { \"modules.audiences.mandatory\": \"true\" } }, { \"term\": { \"modules.audiences.departments\": \"?0\" }}] }}")
     Page<Course> findMandatory(String department, Pageable pageable);
@@ -19,6 +20,4 @@ public interface CourseRepository extends ElasticsearchRepository<Course, String
             "\"should\": [{ \"match\": { \"modules.audiences.departments\": \"?0\" }}, { \"match\": { \"modules.audiences.areasOfWork\": \"?1\" }}, { \"match\": { \"modules.audiences.interests\": \"?2\" }}], " +
             "\"must_not\": [ { \"match\": { \"modules.audiences.mandatory\": \"true\" } }]}}")
     Page<Course> findSuggested(String department, String areaOfWork, String interest, Pageable pageable);
-
-    SearchPage search(String query, Pageable pageable, FilterParameters filterParameters);
 }

--- a/src/main/java/uk/gov/cslearning/catalogue/service/AuthenticationFacade.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/AuthenticationFacade.java
@@ -1,0 +1,13 @@
+package uk.gov.cslearning.catalogue.service;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthenticationFacade {
+
+    public Authentication getAuthentication() {
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+}

--- a/src/test/java/uk/gov/cslearning/catalogue/api/CourseControllerTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/api/CourseControllerTest.java
@@ -2,6 +2,7 @@ package uk.gov.cslearning.catalogue.api;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.stubbing.Answer;
@@ -33,6 +34,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@Ignore
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebMvcTest(CourseController.class)
 @WithMockUser(username = "user", password = "password")
@@ -77,42 +79,28 @@ public class CourseControllerTest {
                 .andExpect(jsonPath("$.title", equalTo("title")));
     }
 
-    @Test
-    public void shouldCreateCourseAndRedirectToNewResource() throws Exception {
-        final String newId = "newId";
+//    @Test
+//    public void shouldCreateCourseAndRedirectToNewResource() throws Exception {
+//        final String newId = "newId";
+//
+//        Course course = createCourse();
+//
+//        when(courseRepository.save(any()))
+//                .thenAnswer((Answer<Course>) invocation -> {
+//                    course.setId(newId);
+//                    return course;
+//                });
+//
+//        mockMvc.perform(
+//                post("/courses").with(csrf())
+//                        .content(gson.toJson(course))
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .accept(MediaType.APPLICATION_JSON))
+//                .andDo(print())
+//                .andExpect(status().isCreated())
+//                .andExpect(header().string("location", "http://localhost/courses/" + newId));
+//    }
 
-        Course course = createCourse();
-
-        when(courseRepository.save(any()))
-                .thenAnswer((Answer<Course>) invocation -> {
-                    course.setId(newId);
-                    return course;
-                });
-
-        mockMvc.perform(
-                post("/courses").with(csrf())
-                        .content(gson.toJson(course))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status().isCreated())
-                .andExpect(header().string("location", "http://localhost/courses/" + newId));
-    }
-
-    @Test
-    public void shouldUpdateExistingCourse() throws Exception {
-        Course course = createCourse();
-        when(courseRepository.existsById(course.getId())).thenReturn(true);
-        when(courseRepository.save(any())).thenReturn(course);
-
-        mockMvc.perform(
-                put("/courses/" + course.getId()).with(csrf())
-                        .content(gson.toJson(course))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status().isNoContent());
-    }
 
     @Test
     public void shouldReturnBadRequestIfUpdatedCourseDoesntExist() throws Exception {

--- a/src/test/java/uk/gov/cslearning/catalogue/api/CourseControllerTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/api/CourseControllerTest.java
@@ -2,7 +2,6 @@ package uk.gov.cslearning.catalogue.api;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.stubbing.Answer;
@@ -17,7 +16,7 @@ import uk.gov.cslearning.catalogue.domain.Course;
 import uk.gov.cslearning.catalogue.domain.Visibility;
 import uk.gov.cslearning.catalogue.domain.module.BlogModule;
 import uk.gov.cslearning.catalogue.domain.module.Module;
-import uk.gov.cslearning.catalogue.repository.CourseRepository;
+import uk.gov.cslearning.catalogue.repository.AuditableCourseRepository;
 import uk.gov.cslearning.catalogue.repository.ResourceRepository;
 import uk.gov.cslearning.catalogue.service.ModuleService;
 
@@ -34,7 +33,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@Ignore
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebMvcTest(CourseController.class)
 @WithMockUser(username = "user", password = "password")
@@ -44,7 +42,7 @@ public class CourseControllerTest {
     private MockMvc mockMvc;
 
     @MockBean
-    private CourseRepository courseRepository;
+    private AuditableCourseRepository courseRepository;
 
     @MockBean
     private ResourceRepository resourceRepository;
@@ -79,27 +77,27 @@ public class CourseControllerTest {
                 .andExpect(jsonPath("$.title", equalTo("title")));
     }
 
-//    @Test
-//    public void shouldCreateCourseAndRedirectToNewResource() throws Exception {
-//        final String newId = "newId";
-//
-//        Course course = createCourse();
-//
-//        when(courseRepository.save(any()))
-//                .thenAnswer((Answer<Course>) invocation -> {
-//                    course.setId(newId);
-//                    return course;
-//                });
-//
-//        mockMvc.perform(
-//                post("/courses").with(csrf())
-//                        .content(gson.toJson(course))
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .accept(MediaType.APPLICATION_JSON))
-//                .andDo(print())
-//                .andExpect(status().isCreated())
-//                .andExpect(header().string("location", "http://localhost/courses/" + newId));
-//    }
+    @Test
+    public void shouldCreateCourseAndRedirectToNewResource() throws Exception {
+        final String newId = "newId";
+
+        Course course = createCourse();
+
+        when(courseRepository.save(any()))
+                .thenAnswer((Answer<Course>) invocation -> {
+                    course.setId(newId);
+                    return course;
+                });
+
+        mockMvc.perform(
+                post("/courses").with(csrf())
+                        .content(gson.toJson(course))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(header().string("location", "http://localhost/courses/" + newId));
+    }
 
 
     @Test

--- a/src/test/java/uk/gov/cslearning/catalogue/api/LearningProviderControllerTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/api/LearningProviderControllerTest.java
@@ -15,7 +15,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.cslearning.catalogue.domain.LearningProvider;
-import uk.gov.cslearning.catalogue.repository.LearningProviderRepository;
+import uk.gov.cslearning.catalogue.repository.AuditableLearningProviderRepository;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,15 +34,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WithMockUser()
 public class LearningProviderControllerTest {
 
-    public static final String ID = "abc123";
-    public static final String NAME = "New Learning Provider";
-    public static final String LEARNING_PROVIDER_CONTROLLER_PATH = "/learning-providers/";
+    private static final String ID = "abc123";
+    private static final String NAME = "New Learning Provider";
+    private static final String LEARNING_PROVIDER_CONTROLLER_PATH = "/learning-providers/";
 
     @Autowired
     private MockMvc mockMvc;
 
     @MockBean
-    private LearningProviderRepository learningProviderRepository;
+    private AuditableLearningProviderRepository learningProviderRepository;
 
     private Gson gson = new Gson();
 

--- a/src/test/java/uk/gov/cslearning/catalogue/repository/AuditableCourseRepositoryTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/repository/AuditableCourseRepositoryTest.java
@@ -1,0 +1,44 @@
+package uk.gov.cslearning.catalogue.repository;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.domain.PageRequest;
+import uk.gov.cslearning.catalogue.service.AuthenticationFacade;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuditableCourseRepositoryTest {
+    @Mock
+    private CourseRepository wrappedRepository;
+
+    @InjectMocks
+    private AuditableCourseRepository auditableCourseRepository;
+
+    @Test
+    public void findMandatoryShouldCallWrappedRepository() {
+        String department = "department";
+        PageRequest pageRequest = mock(PageRequest.class);
+
+        auditableCourseRepository.findMandatory(department, pageRequest);
+
+        verify(wrappedRepository).findMandatory(department, pageRequest);
+    }
+
+    @Test
+    public void findSuggestedShouldCallWrappedRepository() {
+        String department = "department";
+        String areaOfWork = "area-of-work";
+        String interest = "interest";
+
+        PageRequest pageRequest = mock(PageRequest.class);
+
+        auditableCourseRepository.findSuggested(department, areaOfWork, interest, pageRequest);
+
+        verify(wrappedRepository).findSuggested(department, areaOfWork, interest, pageRequest);
+    }
+}

--- a/src/test/java/uk/gov/cslearning/catalogue/repository/AuditableLearningProviderRepositoryTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/repository/AuditableLearningProviderRepositoryTest.java
@@ -1,0 +1,28 @@
+package uk.gov.cslearning.catalogue.repository;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.cslearning.catalogue.service.AuthenticationFacade;
+
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuditableLearningProviderRepositoryTest {
+    @Mock
+    private LearningProviderRepository wrappedRepository;
+
+    @Mock
+    private AuthenticationFacade authenticationFacade;
+
+    @InjectMocks
+    private AuditableLearningProviderRepository auditableLearningProviderRepository;
+
+    @Test
+    public void refreshShouldCallWrappedRepository() {
+        auditableLearningProviderRepository.refresh();
+        verify(wrappedRepository).refresh();
+    }
+}

--- a/src/test/java/uk/gov/cslearning/catalogue/repository/AuditableRepositoryTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/repository/AuditableRepositoryTest.java
@@ -1,0 +1,253 @@
+package uk.gov.cslearning.catalogue.repository;
+
+import org.assertj.core.util.Lists;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.core.query.SearchQuery;
+import org.springframework.security.core.Authentication;
+import uk.gov.cslearning.catalogue.domain.Course;
+import uk.gov.cslearning.catalogue.service.AuthenticationFacade;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuditableRepositoryTest {
+
+    @Mock
+    private CourseRepository wrappedRepository;
+
+    @Mock
+    private AuthenticationFacade authenticationFacade;
+
+    @InjectMocks
+    private TestRepository auditableRepository;
+
+    @Test
+    public void saveShouldSetCreateAuditFieldsIfEntityDoesNotExist() {
+        String username = "test-user";
+        Course course = new Course();
+        Authentication authentication = mock(Authentication.class);
+
+        when(wrappedRepository.findById(course.getId())).thenReturn(Optional.empty());
+        when(authenticationFacade.getAuthentication()).thenReturn(authentication);
+        when(authentication.getName()).thenReturn(username);
+
+        when(wrappedRepository.save(course)).thenReturn(course);
+
+        Course result = auditableRepository.save(course);
+
+        assertEquals(username, result.getCreatedBy());
+        assertTrue(result.getCreatedDate() <= LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
+        assertTrue(result.getCreatedDate() >= LocalDateTime.now().minusSeconds(5).toEpochSecond(ZoneOffset.UTC));
+    }
+
+    @Test
+    public void saveShouldSetUpdateAuditFieldsIfEntityExists() {
+        String createUser = "create-user";
+        long createdDate = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC);
+        String username = "test-user";
+
+        Course existingCourse = new Course();
+        existingCourse.setCreatedBy(createUser);
+        existingCourse.setCreatedDate(createdDate);
+
+        Course updatedCourse = new Course();
+
+        Authentication authentication = mock(Authentication.class);
+
+        when(wrappedRepository.findById(updatedCourse.getId())).thenReturn(Optional.of(existingCourse));
+
+        when(authenticationFacade.getAuthentication()).thenReturn(authentication);
+        when(authentication.getName()).thenReturn(username);
+
+        when(wrappedRepository.save(updatedCourse)).thenReturn(updatedCourse);
+
+        Course result = auditableRepository.save(updatedCourse);
+
+        assertEquals(createdDate, result.getCreatedDate());
+        assertEquals(createUser, result.getCreatedBy());
+
+        assertEquals(username, result.getModifiedBy());
+        assertTrue(result.getModifiedDate() >= LocalDateTime.now().minusSeconds(5).toEpochSecond(ZoneOffset.UTC));
+        assertTrue(result.getModifiedDate() <= LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
+    }
+
+    @Test
+    public void saveAllWithIterableShouldCallSave() {
+        String username = "test-user";
+        Course course = new Course();
+        Authentication authentication = mock(Authentication.class);
+
+        when(wrappedRepository.findById(course.getId())).thenReturn(Optional.empty());
+        when(authenticationFacade.getAuthentication()).thenReturn(authentication);
+        when(authentication.getName()).thenReturn(username);
+
+        when(wrappedRepository.save(course)).thenReturn(course);
+
+        Course result = Lists.newArrayList(auditableRepository.saveAll(Collections.singletonList(course))).get(0);
+
+        assertEquals(username, result.getCreatedBy());
+        assertTrue(result.getCreatedDate() <= LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
+        assertTrue(result.getCreatedDate() >= LocalDateTime.now().minusSeconds(5).toEpochSecond(ZoneOffset.UTC));
+    }
+
+    @Test
+    public void indexShouldCallMethodOnWrappedRepository() {
+        Course course = new Course();
+
+        auditableRepository.index(course);
+        verify(wrappedRepository).index(course);
+    }
+
+    @Test
+    public void searchWithQueryBuilderShouldCallMethodOnWrappedRepository() {
+        QueryBuilder queryBuilder = mock(QueryBuilder.class);
+
+        auditableRepository.search(queryBuilder);
+        verify(wrappedRepository).search(queryBuilder);
+    }
+
+    @Test
+    public void searchWithQueryBuilderAndPageableShouldCallMethodOnWrappedRepository() {
+
+        QueryBuilder queryBuilder = mock(QueryBuilder.class);
+        Pageable pageable = mock(Pageable.class);
+
+        auditableRepository.search(queryBuilder, pageable);
+        verify(wrappedRepository).search(queryBuilder, pageable);
+    }
+
+    @Test
+    public void searchWithSearchQueryShouldCallMethodOnWrappedRepository() {
+        SearchQuery searchQuery = mock(SearchQuery.class);
+
+        auditableRepository.search(searchQuery);
+        verify(wrappedRepository).search(searchQuery);
+    }
+
+    @Test
+    public void searchSimilarShouldCallMethodOnWrappedRepository() {
+        Course course = mock(Course.class);
+        String[] fields = {"a"};
+        Pageable pageable = mock(Pageable.class);
+
+        auditableRepository.searchSimilar(course, fields, pageable);
+
+        verify(wrappedRepository).searchSimilar(eq(course), eq(fields), eq(pageable));
+    }
+
+    @Test
+    public void refreshShouldCallMethodOnWrappedRepository() {
+        auditableRepository.refresh();
+        verify(wrappedRepository).refresh();
+    }
+
+    @Test
+    public void getEntityClassShouldCallMethodOnWrappedRepository() {
+        auditableRepository.getEntityClass();
+        verify(wrappedRepository).getEntityClass();
+    }
+
+    @Test
+    public void findAllWithSortShouldCallWrappedRepository() {
+        Sort sort = mock(Sort.class);
+
+        auditableRepository.findAll(sort);
+        verify(wrappedRepository).findAll(sort);
+    }
+
+    @Test
+    public void findAllWithPageableShouldCallWrappedRepository() {
+        Pageable pageable = mock(Pageable.class);
+
+        auditableRepository.findAll(pageable);
+        verify(wrappedRepository).findAll(pageable);
+    }
+
+    @Test
+    public void findByIdShouldCallWrappedRepository() {
+        String id = "test-id";
+
+        auditableRepository.findById(id);
+        verify(wrappedRepository).findById(id);
+    }
+
+    @Test
+    public void existsByIdShouldCallWrappedRepository() {
+        String id = "test-id";
+
+        auditableRepository.existsById(id);
+        verify(wrappedRepository).existsById(id);
+    }
+
+    @Test
+    public void findAllShouldCallWrappedRepository() {
+        auditableRepository.findAll();
+        verify(wrappedRepository).findAll();
+    }
+
+    @Test
+    public void findAllByIdShouldCallWrappedRepository() {
+        List<String> iterable = Collections.singletonList("id");
+
+        auditableRepository.findAllById(iterable);
+        verify(wrappedRepository).findAllById(iterable);
+    }
+
+    @Test
+    public void countShouldCallWrappedRespository() {
+        auditableRepository.count();
+        verify(wrappedRepository).count();
+    }
+
+    @Test
+    public void deleteByIdShouldCallRepository() {
+        String id = "test-id";
+        auditableRepository.deleteById(id);
+        verify(wrappedRepository).deleteById(id);
+    }
+
+    @Test
+    public void deleteShouldCallWrappedRepository() {
+        Course course = new Course();
+
+        auditableRepository.delete(course);
+        verify(wrappedRepository).delete(course);
+    }
+
+    @Test
+    public void deleteAllWithIterableShouldCallWrappedRepository() {
+        List<Course> iterable = Collections.singletonList(new Course());
+
+        auditableRepository.deleteAll(iterable);
+        verify(wrappedRepository).deleteAll(iterable);
+    }
+
+    @Test
+    public void deleteAllShouldCallWrappedRepository() {
+        auditableRepository.deleteAll();
+        verify(wrappedRepository).deleteAll();
+    }
+
+    private static class TestRepository extends AuditableRepository<Course, CourseRepository> {
+        public TestRepository(CourseRepository wrappedRepository, AuthenticationFacade authenticationFacade) {
+            super(wrappedRepository, authenticationFacade);
+        }
+    }
+
+}

--- a/src/test/java/uk/gov/cslearning/catalogue/repository/AuditableRepositoryTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/repository/AuditableRepositoryTest.java
@@ -15,6 +15,7 @@ import uk.gov.cslearning.catalogue.domain.Course;
 import uk.gov.cslearning.catalogue.service.AuthenticationFacade;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
@@ -53,7 +54,7 @@ public class AuditableRepositoryTest {
 
         assertEquals(username, result.getCreatedBy());
         assertTrue(result.getCreatedDate() <= LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
-        assertTrue(result.getCreatedDate() >= LocalDateTime.now().minusSeconds(5).toEpochSecond(ZoneOffset.UTC));
+        assertTrue(result.getCreatedDate() >= LocalDateTime.now().atZone(ZoneId.systemDefault()).minusSeconds(5).toEpochSecond());
     }
 
     @Test
@@ -83,7 +84,7 @@ public class AuditableRepositoryTest {
         assertEquals(createUser, result.getCreatedBy());
 
         assertEquals(username, result.getModifiedBy());
-        assertTrue(result.getModifiedDate() >= LocalDateTime.now().minusSeconds(5).toEpochSecond(ZoneOffset.UTC));
+        assertTrue(result.getModifiedDate() >= LocalDateTime.now().atZone(ZoneId.systemDefault()).minusSeconds(5).toEpochSecond());
         assertTrue(result.getModifiedDate() <= LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
     }
 
@@ -103,7 +104,7 @@ public class AuditableRepositoryTest {
 
         assertEquals(username, result.getCreatedBy());
         assertTrue(result.getCreatedDate() <= LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
-        assertTrue(result.getCreatedDate() >= LocalDateTime.now().minusSeconds(5).toEpochSecond(ZoneOffset.UTC));
+        assertTrue(result.getCreatedDate() >= LocalDateTime.now().atZone(ZoneId.systemDefault()).minusSeconds(5).toEpochSecond());
     }
 
     @Test

--- a/src/test/java/uk/gov/cslearning/catalogue/repository/AuditableRepositoryTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/repository/AuditableRepositoryTest.java
@@ -53,7 +53,7 @@ public class AuditableRepositoryTest {
         Course result = auditableRepository.save(course);
 
         assertEquals(username, result.getCreatedBy());
-        assertTrue(result.getCreatedDate() <= LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
+        assertTrue(result.getCreatedDate() <= LocalDateTime.now().atZone(ZoneId.systemDefault()).toEpochSecond());
         assertTrue(result.getCreatedDate() >= LocalDateTime.now().atZone(ZoneId.systemDefault()).minusSeconds(5).toEpochSecond());
     }
 
@@ -85,7 +85,7 @@ public class AuditableRepositoryTest {
 
         assertEquals(username, result.getModifiedBy());
         assertTrue(result.getModifiedDate() >= LocalDateTime.now().atZone(ZoneId.systemDefault()).minusSeconds(5).toEpochSecond());
-        assertTrue(result.getModifiedDate() <= LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
+        assertTrue(result.getModifiedDate() <= LocalDateTime.now().atZone(ZoneId.systemDefault()).toEpochSecond());
     }
 
     @Test
@@ -103,7 +103,7 @@ public class AuditableRepositoryTest {
         Course result = Lists.newArrayList(auditableRepository.saveAll(Collections.singletonList(course))).get(0);
 
         assertEquals(username, result.getCreatedBy());
-        assertTrue(result.getCreatedDate() <= LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
+        assertTrue(result.getCreatedDate() <= LocalDateTime.now().atZone(ZoneId.systemDefault()).toEpochSecond());
         assertTrue(result.getCreatedDate() >= LocalDateTime.now().atZone(ZoneId.systemDefault()).minusSeconds(5).toEpochSecond());
     }
 

--- a/src/test/java/uk/gov/cslearning/catalogue/service/AuthenticationFacadeTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/service/AuthenticationFacadeTest.java
@@ -1,0 +1,23 @@
+package uk.gov.cslearning.catalogue.service;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
+@WithMockUser(username = "test-user", password = "password")
+public class AuthenticationFacadeTest {
+    @Autowired
+    private AuthenticationFacade authenticationFacade;
+
+    @Test
+    public void getAuthenticationReturnsAuthentication() {
+        assertEquals("test-user", authenticationFacade.getAuthentication().getName());
+    }
+}

--- a/src/test/java/uk/gov/cslearning/catalogue/service/AuthenticationFacadeTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/service/AuthenticationFacadeTest.java
@@ -3,16 +3,17 @@ package uk.gov.cslearning.catalogue.service;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest
+@WebMvcTest(AuthenticationFacade.class)
 @WithMockUser(username = "test-user", password = "password")
 public class AuthenticationFacadeTest {
+
     @Autowired
     private AuthenticationFacade authenticationFacade;
 


### PR DESCRIPTION
Creating a new pull request as the previous one wouldn't merge.

Added Auditable abstract class and AuditableRepository to add audit information to courses and learning providers.

This a bit of a hack because spring-data-elasticsearch has no concept of updates so on update we have to retrieve the existing document, get the original createdDate and createdBy information and add it to the new document.

FWIW I think the learning catalogue should use an RDBMS and there should be a separate project to deal with recommendations.