### PR TITLE
LPFG-878: Learning Catalogue is still using module audiences in queries

### DIFF
--- a/src/main/java/uk/gov/cslearning/catalogue/repository/CourseRepository.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/CourseRepository.java
@@ -12,12 +12,10 @@ import uk.gov.cslearning.catalogue.domain.SearchPage;
 @Repository
 public interface CourseRepository extends ElasticsearchRepository<Course, String>, ResourceSearchRepository{
 
-    @Query("{ \"bool\": { \"must\": [{ \"match\": { \"modules.audiences.mandatory\": \"true\" } }, { \"term\": { \"modules.audiences.departments\": \"?0\" }}] }}")
+    @Query("{ \"bool\": { \"must\": [{ \"match\": { \"audiences.type\": \"REQUIRED_LEARNING\" } }, { \"term\": { \"audiences.departments\": \"?0\" }}] }}")
     Page<Course> findMandatory(String department, Pageable pageable);
 
-    @Query("{ \"bool\": { " +
-            "\"should\": [{ \"match\": { \"modules.audiences.departments\": \"?0\" }}, { \"match\": { \"modules.audiences.areasOfWork\": \"?1\" }}, { \"match\": { \"modules.audiences.interests\": \"?2\" }}], " +
-            "\"must_not\": [ { \"match\": { \"modules.audiences.mandatory\": \"true\" } }]}}")
+    @Query("{\"bool\": {\"should\": [{\"match\": {\"audiences.departments\": {\"query\": \"?0\",\"zero_terms_query\": \"none\"}}},{\"match\": {\"audiences.areasOfWork\": {\"query\": \"?1\",\"zero_terms_query\": \"none\"}}},{\"match\": {\"audiences.interests\": {\"query\": \"?2\",\"zero_terms_query\": \"none\"}}}],\"must_not\": [{\"match\": {\"audiences.type\": \"REQUIRED_LEARNING\"}}]}}")
     Page<Course> findSuggested(String department, String areaOfWork, String interest, Pageable pageable);
 
     SearchPage search(String query, Pageable pageable, FilterParameters filterParameters);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -22,7 +22,7 @@ elasticsearch:
 
 azure:
   account:
-    name: ${AZURE_ACCOUNT_NAME}
+    name: ${AZURE_ACCOUNT_NAME:lpgdev}
     key: ${AZURE_ACCOUNT_KEY}
   storage:
     container: lpgdevcontent


### PR DESCRIPTION
Updated queries to call audiences directly. 
Added 'zero_terms_query' parameter to pick up default 'none' argument.