### PR TITLE
Lpfg 669 event status

### DIFF
--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/CancellationReason.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/CancellationReason.java
@@ -1,0 +1,31 @@
+package uk.gov.cslearning.catalogue.domain.module;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+
+public enum CancellationReason {
+    UNAVAILABLE("Unavailable"),VENUE("Venue");
+
+    private final String value;
+
+    CancellationReason(String value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static CancellationReason forValue(String value) {
+        return Arrays.stream(CancellationReason.values())
+        .filter(v -> v.value.equalsIgnoreCase(value))
+        .findAny()
+        .orElseThrow(() -> new Error("Error, unknown status: " + value));
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}
+
+

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/Event.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/Event.java
@@ -19,6 +19,8 @@ public class Event {
 
     private EventStatus status;
 
+    private CancellationReason cancellationReason;
+
     public Event() {
     }
 
@@ -59,5 +61,13 @@ public class Event {
 
     public void setStatus(EventStatus status) {
         this.status = status;
+    }
+
+    public CancellationReason getCancellationReason() {
+        return cancellationReason;
+    }
+
+    public void setCancellationReason(CancellationReason cancellationReason) {
+        this.cancellationReason = cancellationReason;
     }
 }

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/Event.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/Event.java
@@ -17,6 +17,8 @@ public class Event {
 
     private List<DateRange> dateRanges = new ArrayList<>();
 
+    private EventStatus status;
+
     public Event() {
     }
 
@@ -49,5 +51,13 @@ public class Event {
 
     public void setVenue(Venue venue) {
         this.venue = venue;
+    }
+
+    public EventStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(EventStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/EventStatus.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/EventStatus.java
@@ -1,0 +1,30 @@
+package uk.gov.cslearning.catalogue.domain.module;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+
+public enum EventStatus {
+    ACTIVE("Active"),CANCELLED("Cancelled");
+
+    private final String value;
+
+    EventStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static EventStatus forValue(String value) {
+        return Arrays.stream(EventStatus.values())
+                .filter(v -> v.value.equalsIgnoreCase(value))
+                .findAny()
+                .orElseThrow(() -> new Error("Error, unknown status: " + value));
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}
+

--- a/src/main/java/uk/gov/cslearning/catalogue/service/CourseService.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/CourseService.java
@@ -31,7 +31,10 @@ public class CourseService {
     private Course getCourseEventsAvailability(Course course) {
         course.getModules().forEach(module -> {
             if(module instanceof FaceToFaceModule) {
-                ((FaceToFaceModule) module).getEvents().forEach(event -> eventService.getEventAvailability(event));
+                ((FaceToFaceModule) module).getEvents().forEach(event -> {
+                    eventService.getEventAvailability(event);
+                    event.setStatus(eventService.getStatus(event.getId()));
+                });
             }
         });
 

--- a/src/main/java/uk/gov/cslearning/catalogue/service/EventService.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/EventService.java
@@ -3,6 +3,7 @@ package uk.gov.cslearning.catalogue.service;
 import org.springframework.stereotype.Service;
 import uk.gov.cslearning.catalogue.domain.Course;
 import uk.gov.cslearning.catalogue.domain.module.Event;
+import uk.gov.cslearning.catalogue.domain.module.EventStatus;
 import uk.gov.cslearning.catalogue.domain.module.FaceToFaceModule;
 import uk.gov.cslearning.catalogue.repository.CourseRepository;
 import uk.gov.cslearning.catalogue.service.record.LearnerRecordService;
@@ -73,6 +74,7 @@ public class EventService {
         if(result.isPresent()){
             Event event = result.get();
             event = getEventAvailability(event);
+            event.setStatus(getStatus(eventId));
         }
 
         return result;
@@ -90,5 +92,9 @@ public class EventService {
         });
 
         return event;
+    }
+
+    public EventStatus getStatus(String eventId){
+        return learnerRecordService.getEventStatus(eventId);
     }
 }

--- a/src/main/java/uk/gov/cslearning/catalogue/service/EventService.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/EventService.java
@@ -78,7 +78,7 @@ public class EventService {
             event.setStatus(getStatus(eventId));
 
             if(event.getStatus() == EventStatus.CANCELLED){
-                event.setCancellationReason(getCancellatioReason(eventId));
+                event.setCancellationReason(getCancellationReason(eventId));
             }
         }
 
@@ -103,7 +103,7 @@ public class EventService {
         return learnerRecordService.getEventStatus(eventId);
     }
 
-    public CancellationReason getCancellatioReason(String eventId) {
+    public CancellationReason getCancellationReason(String eventId) {
         return learnerRecordService.getCancellationReason(eventId);
     }
 }

--- a/src/main/java/uk/gov/cslearning/catalogue/service/EventService.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/EventService.java
@@ -2,6 +2,7 @@ package uk.gov.cslearning.catalogue.service;
 
 import org.springframework.stereotype.Service;
 import uk.gov.cslearning.catalogue.domain.Course;
+import uk.gov.cslearning.catalogue.domain.module.CancellationReason;
 import uk.gov.cslearning.catalogue.domain.module.Event;
 import uk.gov.cslearning.catalogue.domain.module.EventStatus;
 import uk.gov.cslearning.catalogue.domain.module.FaceToFaceModule;
@@ -75,6 +76,10 @@ public class EventService {
             Event event = result.get();
             event = getEventAvailability(event);
             event.setStatus(getStatus(eventId));
+
+            if(event.getStatus() == EventStatus.CANCELLED){
+                event.setCancellationReason(getCancellatioReason(eventId));
+            }
         }
 
         return result;
@@ -96,5 +101,9 @@ public class EventService {
 
     public EventStatus getStatus(String eventId){
         return learnerRecordService.getEventStatus(eventId);
+    }
+
+    public CancellationReason getCancellatioReason(String eventId) {
+        return learnerRecordService.getCancellationReason(eventId);
     }
 }

--- a/src/main/java/uk/gov/cslearning/catalogue/service/record/LearnerRecordService.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/record/LearnerRecordService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.beans.factory.annotation.Value;
+import uk.gov.cslearning.catalogue.domain.module.CancellationReason;
 import uk.gov.cslearning.catalogue.domain.module.EventStatus;
 import uk.gov.cslearning.catalogue.service.IdentityTokenServices;
 import uk.gov.cslearning.catalogue.service.record.model.Booking;
@@ -52,8 +53,21 @@ public class LearnerRecordService {
             RequestEntity requestEntity = requestEntityFactory.createGetRequest(String.format(eventUrlFormat, eventId));
             ResponseEntity<Event> responseEntity = restTemplate.exchange(requestEntity, Event.class);
 
-            Event event = (Event) responseEntity.getBody();
+            Event event = responseEntity.getBody();
             return EventStatus.forValue(event.getStatus());
+        } catch (RequestEntityException | RestClientException e) {
+            LOGGER.error("Could not get event from learner record: ", e.getLocalizedMessage());
+            return null;
+        }
+    }
+
+    public CancellationReason getCancellationReason(String eventId) {
+        try{
+            RequestEntity requestEntity = requestEntityFactory.createGetRequest(String.format(eventUrlFormat, eventId));
+            ResponseEntity<Event> responseEntity = restTemplate.exchange(requestEntity, Event.class);
+
+            Event event = responseEntity.getBody();
+            return CancellationReason.forValue(event.getCancellationReason());
         } catch (RequestEntityException | RestClientException e) {
             LOGGER.error("Could not get event from learner record: ", e.getLocalizedMessage());
             return null;

--- a/src/main/java/uk/gov/cslearning/catalogue/service/record/model/Event.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/record/model/Event.java
@@ -9,6 +9,8 @@ public class Event {
 
     private String status;
 
+    private String cancellationReason;
+
     public Event() {}
 
     public Integer getId() {
@@ -37,6 +39,14 @@ public class Event {
 
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    public String getCancellationReason() {
+        return cancellationReason;
+    }
+
+    public void setCancellationReason(String cancellationReason) {
+        this.cancellationReason = cancellationReason;
     }
 }
 

--- a/src/main/java/uk/gov/cslearning/catalogue/service/record/model/Event.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/record/model/Event.java
@@ -1,0 +1,42 @@
+package uk.gov.cslearning.catalogue.service.record.model;
+
+public class Event {
+    private Integer id;
+
+    private String uid;
+
+    private String path;
+
+    private String status;
+
+    public Event() {}
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getUid() {
+        return uid;
+    }
+
+    public void setUid(String uid) {
+        this.uid = uid;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,7 +42,8 @@ management:
 
 record:
   serviceUrl: ${LEARNER_RECORD_URL:http://localhost:9000}
-  bookingUrlFormat: "${record.serviceUrl}/event/%s/booking"
+  eventUrlFormat: "${record.serviceUrl}/event/%s"
+  bookingUrlFormat: "${record.eventUrlFormat}/booking"
 
 registry:
   serviceUrl: ${REGISTRY_SERVICE_URL:http://localhost:9002}

--- a/src/test/java/uk/gov/cslearning/catalogue/service/CourseServiceTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/service/CourseServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.cslearning.catalogue.domain.Course;
 import uk.gov.cslearning.catalogue.domain.module.Event;
+import uk.gov.cslearning.catalogue.domain.module.EventStatus;
 import uk.gov.cslearning.catalogue.domain.module.FaceToFaceModule;
 import uk.gov.cslearning.catalogue.domain.module.Module;
 import uk.gov.cslearning.catalogue.repository.CourseRepository;
@@ -31,7 +32,7 @@ public class CourseServiceTest {
     private CourseService courseService;
 
     @Test
-    public void shouldFindCourseAndGetEventAvailabilities() {
+    public void shouldFindCourseAndGetEventAvailabilitiesAndEventStatus() {
         String courseId = "courseId";
 
         Course course = new Course();
@@ -48,11 +49,13 @@ public class CourseServiceTest {
 
         Mockito.when(courseRepository.findById(courseId)).thenReturn(Optional.of(course));
         Mockito.when(eventService.getEventAvailability(event)).thenReturn(event);
+        Mockito.when(eventService.getStatus(event.getId())).thenReturn(EventStatus.ACTIVE);
 
         Assert.assertEquals(courseService.findById(courseId), Optional.of(course));
 
         Mockito.verify(courseRepository).findById(courseId);
         Mockito.verify(eventService).getEventAvailability(event);
+        Mockito.verify(eventService).getStatus(event.getId());
     }
 
 }

--- a/src/test/java/uk/gov/cslearning/catalogue/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/service/EventServiceTest.java
@@ -5,13 +5,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.InjectMocks;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.cslearning.catalogue.domain.Course;
-import uk.gov.cslearning.catalogue.domain.module.Event;
-import uk.gov.cslearning.catalogue.domain.module.FaceToFaceModule;
-import uk.gov.cslearning.catalogue.domain.module.Module;
-import uk.gov.cslearning.catalogue.domain.module.Venue;
+import uk.gov.cslearning.catalogue.domain.module.*;
 import uk.gov.cslearning.catalogue.repository.CourseRepository;
 import uk.gov.cslearning.catalogue.service.record.LearnerRecordService;
 import uk.gov.cslearning.catalogue.service.record.model.Booking;
@@ -19,6 +15,7 @@ import uk.gov.cslearning.catalogue.service.record.model.BookingStatus;
 
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.*;
 
@@ -55,7 +52,7 @@ public class EventServiceTest {
         modules.add(module);
         course.setModules(modules);
 
-        Mockito.when(courseRepository.findById(courseId)).thenReturn(Optional.of(course));
+        when(courseRepository.findById(courseId)).thenReturn(Optional.of(course));
 
         Assert.assertEquals(eventService.save(courseId, moduleId, newEvent), newEvent);
 
@@ -92,8 +89,8 @@ public class EventServiceTest {
         List<Booking> bookings = new ArrayList<>();
         bookings.add(booking);
 
-        Mockito.when(courseRepository.findById(courseId)).thenReturn(Optional.of(course));
-        Mockito.when(learnerRecordService.getEventBookings(savedEvent.getId())).thenReturn(bookings);
+        when(courseRepository.findById(courseId)).thenReturn(Optional.of(course));
+        when(learnerRecordService.getEventBookings(savedEvent.getId())).thenReturn(bookings);
 
         int availability = (venue.getCapacity() - bookings.size());
 
@@ -104,5 +101,31 @@ public class EventServiceTest {
 
         verify(courseRepository).findById(courseId);
         verify(learnerRecordService).getEventBookings(savedEvent.getId());
+    }
+
+    @Test
+    public void shouldGetEventStatus() {
+        String eventId = "eventId";
+
+        EventStatus eventStatus = EventStatus.ACTIVE;
+
+        when(learnerRecordService.getEventStatus(eventId)).thenReturn(eventStatus);
+
+        Assert.assertEquals(eventService.getStatus(eventId), eventStatus);
+
+        verify(learnerRecordService).getEventStatus(eventId);
+    }
+
+    @Test
+    public void shouldGetCancellationReason() {
+        String eventId = "eventId";
+
+        CancellationReason cancellationReason = CancellationReason.UNAVAILABLE;
+
+        when(learnerRecordService.getCancellationReason(eventId)).thenReturn(cancellationReason);
+
+        Assert.assertEquals(eventService.getCancellationReason(eventId), cancellationReason);
+
+        verify(learnerRecordService).getCancellationReason(eventId);
     }
 }

--- a/src/test/java/uk/gov/cslearning/catalogue/service/record/LearnerRecordServiceTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/service/record/LearnerRecordServiceTest.java
@@ -17,8 +17,9 @@ public class LearnerRecordServiceTest {
     private RestTemplate restTemplate = Mockito.mock(RestTemplate.class);
     private RequestEntityFactory requestEntityFactory = Mockito.mock(RequestEntityFactory.class);
     private String eventUrlFormat = "testhost:9000/event/%s";
+    private String bookingUrlFormat = "testhost:9000/event/%s/booking";
 
-    private LearnerRecordService learnerRecordService = new LearnerRecordService(restTemplate, requestEntityFactory, eventUrlFormat);
+    private LearnerRecordService learnerRecordService = new LearnerRecordService(restTemplate, requestEntityFactory, eventUrlFormat, bookingUrlFormat);
 
     @Test
     public void shouldReturnEventBookings(){
@@ -38,7 +39,7 @@ public class LearnerRecordServiceTest {
         RequestEntity requestEntity = Mockito.mock(RequestEntity.class);
         ResponseEntity<List<Booking>> responseEntity = Mockito.mock(ResponseEntity.class);
 
-        Mockito.when(requestEntityFactory.createGetRequest(String.format(eventUrlFormat, eventId))).thenReturn(requestEntity);
+        Mockito.when(requestEntityFactory.createGetRequest(String.format(bookingUrlFormat, eventId))).thenReturn(requestEntity);
         Mockito.when(restTemplate.exchange(requestEntity, new ParameterizedTypeReference<List<Booking>>(){})).thenReturn(responseEntity);
         Mockito.when(responseEntity.getBody()).thenReturn(bookings);
 


### PR DESCRIPTION
**Needs to be merged with LPFG-669 from learner-record**

Added status and cancellation reason to events. Get's the status from learner record and if the status is cancelled, then get's the cancellation reason.

- Created enum CancellationReason.java
- Added status and cancellationReason to Event.java
- Created enum EventStatus.java
- In CourseService.java the status of events is found when finding the availability of events
- Added getStatus and getCancellationReason functions to EventService.java
- Added getEventStatus and getCancellationReason functions to LearnerRecordService.java
- Created a learner record model version of Event.java