### PR TITLE
LPFG-1189-cancellation-reason-enums

### DIFF
--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/CancellationReason.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/CancellationReason.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Arrays;
 
 public enum CancellationReason {
-    UNAVAILABLE("Unavailable"),VENUE("Venue");
+    UNAVAILABLE("the event is no longer available"),VENUE("short notice unavailability of the venue");
 
     private final String value;
 


### PR DESCRIPTION
**Needs to be merged with fix/cancellation-reason-enums in learner-record**

Updated the cancellation reason enum values to be the actual cancellation reasons as opposed to the one word description.