### PR TITLE
LPFG 1213 Course Visbility

### DIFF
--- a/src/main/java/uk/gov/cslearning/catalogue/api/ProfileParameters.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/api/ProfileParameters.java
@@ -1,0 +1,58 @@
+package uk.gov.cslearning.catalogue.api;
+
+import java.util.ArrayList;
+
+public class ProfileParameters {
+
+    private String profileDepartment;
+
+    private String profileGrade;
+
+    private ArrayList<String> profileAreasOfWork = new ArrayList<>();
+
+    private ArrayList<String> profileInterests = new ArrayList<>();
+
+    public ProfileParameters() {}
+
+    public String getProfileDepartment() {
+        return profileDepartment;
+    }
+
+    public void setProfileDepartment(String profileDepartment) {
+        this.profileDepartment = profileDepartment;
+    }
+
+    public String getProfileGrade() {
+        return profileGrade;
+    }
+
+    public void setProfileGrade(String profileGrade) {
+        this.profileGrade = profileGrade;
+    }
+
+    public ArrayList<String> getProfileAreasOfWork() {
+        return profileAreasOfWork;
+    }
+
+    public void setProfileAreasOfWork(ArrayList<String> profileAreasOfWork) {
+        this.profileAreasOfWork = profileAreasOfWork;
+    }
+
+    public ArrayList<String> getProfileInterests() {
+        return profileInterests;
+    }
+
+    public void setProfileInterests(ArrayList<String> interests) {
+        this.profileInterests = interests;
+    }
+
+    public boolean hasInterests() {
+        return profileInterests != null && profileInterests.size() != 0;
+    }
+
+    public boolean hasAreasOfWork() {
+        return profileAreasOfWork != null && profileAreasOfWork.size() != 0;
+    }
+}
+
+

--- a/src/main/java/uk/gov/cslearning/catalogue/api/ProfileParameters.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/api/ProfileParameters.java
@@ -4,9 +4,9 @@ import java.util.ArrayList;
 
 public class ProfileParameters {
 
-    private String profileDepartment;
+    private ArrayList<String> profileDepartments;
 
-    private String profileGrade;
+    private ArrayList<String> profileGrades;
 
     private ArrayList<String> profileAreasOfWork = new ArrayList<>();
 
@@ -14,20 +14,20 @@ public class ProfileParameters {
 
     public ProfileParameters() {}
 
-    public String getProfileDepartment() {
-        return profileDepartment;
+    public ArrayList<String> getProfileDepartments() {
+        return profileDepartments;
     }
 
-    public void setProfileDepartment(String profileDepartment) {
-        this.profileDepartment = profileDepartment;
+    public void setProfileDepartments(ArrayList<String> profileDepartments) {
+        this.profileDepartments = profileDepartments;
     }
 
-    public String getProfileGrade() {
-        return profileGrade;
+    public ArrayList<String> getProfileGrades() {
+        return profileGrades;
     }
 
-    public void setProfileGrade(String profileGrade) {
-        this.profileGrade = profileGrade;
+    public void setProfileGrades(ArrayList<String> profileGrades) {
+        this.profileGrades = profileGrades;
     }
 
     public ArrayList<String> getProfileAreasOfWork() {
@@ -44,14 +44,6 @@ public class ProfileParameters {
 
     public void setProfileInterests(ArrayList<String> interests) {
         this.profileInterests = interests;
-    }
-
-    public boolean hasInterests() {
-        return profileInterests != null && profileInterests.size() != 0;
-    }
-
-    public boolean hasAreasOfWork() {
-        return profileAreasOfWork != null && profileAreasOfWork.size() != 0;
     }
 }
 

--- a/src/main/java/uk/gov/cslearning/catalogue/api/SearchController.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/api/SearchController.java
@@ -30,11 +30,11 @@ public class SearchController {
     }
 
     @GetMapping("/courses")
-    public ResponseEntity<SearchResults> search(@RequestParam(name = "status", defaultValue = "Published") String status, String query, FilterParameters filterParameters, PageParameters pageParameters) {
+    public ResponseEntity<SearchResults> search(@RequestParam(name = "status", defaultValue = "Published") String status, String query, FilterParameters filterParameters, ProfileParameters profileParameters, PageParameters pageParameters) {
         LOGGER.debug("Searching courses with query {}", query);
 
         Pageable pageable = pageParameters.getPageRequest();
-        SearchPage searchPage = courseRepository.search(query, pageable, filterParameters, Arrays.stream(status.split(",")).map(Status::forValue).collect(Collectors.toList()));
+        SearchPage searchPage = courseRepository.search(query, pageable, filterParameters, profileParameters, Arrays.stream(status.split(",")).map(Status::forValue).collect(Collectors.toList()));
 
         return ResponseEntity.ok(new SearchResults(searchPage, pageable));
     }

--- a/src/main/java/uk/gov/cslearning/catalogue/api/SearchController.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/api/SearchController.java
@@ -30,11 +30,11 @@ public class SearchController {
     }
 
     @GetMapping("/courses")
-    public ResponseEntity<SearchResults> search(@RequestParam(name = "status", defaultValue = "Published") String status, String query, FilterParameters filterParameters, ProfileParameters profileParameters, PageParameters pageParameters) {
+    public ResponseEntity<SearchResults> search(@RequestParam(name = "status", defaultValue = "Published") String status, @RequestParam(name = "visibility", defaultValue = "PUBLIC") String visibility, String query, FilterParameters filterParameters, ProfileParameters profileParameters, PageParameters pageParameters) {
         LOGGER.debug("Searching courses with query {}", query);
 
         Pageable pageable = pageParameters.getPageRequest();
-        SearchPage searchPage = courseRepository.search(query, pageable, filterParameters, profileParameters, Arrays.stream(status.split(",")).map(Status::forValue).collect(Collectors.toList()));
+        SearchPage searchPage = courseRepository.search(query, pageable, filterParameters, profileParameters, Arrays.stream(status.split(",")).map(Status::forValue).collect(Collectors.toList()), visibility);
 
         return ResponseEntity.ok(new SearchResults(searchPage, pageable));
     }

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/Course.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/Course.java
@@ -42,7 +42,7 @@ public class Course {
     private String preparation;
 
     @NotNull
-    private Visibility visibility;
+    private Visibility visibility = Visibility.PUBLIC;
 
     private Status status = Status.DRAFT;
 

--- a/src/main/java/uk/gov/cslearning/catalogue/repository/CourseRepository.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/CourseRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.cslearning.catalogue.api.FilterParameters;
+import uk.gov.cslearning.catalogue.api.ProfileParameters;
 import uk.gov.cslearning.catalogue.domain.Course;
 import uk.gov.cslearning.catalogue.domain.SearchPage;
 import uk.gov.cslearning.catalogue.domain.Status;
@@ -22,7 +23,7 @@ public interface CourseRepository extends ElasticsearchRepository<Course, String
     @Query("{\"bool\": {\"should\": [{\"match\": {\"audiences.departments\": {\"query\": \"?0\",\"zero_terms_query\": \"none\"}}},{\"match\": {\"audiences.areasOfWork\": {\"query\": \"?1\",\"zero_terms_query\": \"none\"}}},{\"match\": {\"audiences.interests\": {\"query\": \"?2\",\"zero_terms_query\": \"none\"}}}],\"must\": [{\"match\": {\"status\": {\"query\": \"?3\"}}}],\"must_not\": [{\"match\": {\"audiences.type\": \"REQUIRED_LEARNING\"}}]}}")
     Page<Course> findSuggested(String department, String areaOfWork, String interest, String status, Pageable pageable);
 
-    SearchPage search(String query, Pageable pageable, FilterParameters filterParameters, Collection<Status> status);
+    SearchPage search(String query, Pageable pageable, FilterParameters filterParameters, ProfileParameters profileParameters, Collection<Status> status);
 
     Page<Course> findAllByStatusIn(Collection<Status> status, Pageable pageable);
 

--- a/src/main/java/uk/gov/cslearning/catalogue/repository/CourseRepository.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/CourseRepository.java
@@ -23,7 +23,7 @@ public interface CourseRepository extends ElasticsearchRepository<Course, String
     @Query("{\"bool\": {\"should\": [{\"match\": {\"audiences.departments\": {\"query\": \"?0\",\"zero_terms_query\": \"none\"}}},{\"match\": {\"audiences.areasOfWork\": {\"query\": \"?1\",\"zero_terms_query\": \"none\"}}},{\"match\": {\"audiences.interests\": {\"query\": \"?2\",\"zero_terms_query\": \"none\"}}}],\"must\": [{\"match\": {\"status\": {\"query\": \"?3\"}}}],\"must_not\": [{\"match\": {\"audiences.type\": \"REQUIRED_LEARNING\"}}]}}")
     Page<Course> findSuggested(String department, String areaOfWork, String interest, String status, Pageable pageable);
 
-    SearchPage search(String query, Pageable pageable, FilterParameters filterParameters, ProfileParameters profileParameters, Collection<Status> status);
+    SearchPage search(String query, Pageable pageable, FilterParameters filterParameters, ProfileParameters profileParameters, Collection<Status> status, String visbility);
 
     Page<Course> findAllByStatusIn(Collection<Status> status, Pageable pageable);
 

--- a/src/main/java/uk/gov/cslearning/catalogue/repository/CourseSearchRepository.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/CourseSearchRepository.java
@@ -9,5 +9,5 @@ import uk.gov.cslearning.catalogue.domain.Status;
 import java.util.Collection;
 
 public interface CourseSearchRepository {
-    SearchPage search(String query, Pageable pageable, FilterParameters filterParameters, ProfileParameters profileParameters, Collection<Status> status);
+    SearchPage search(String query, Pageable pageable, FilterParameters filterParameters, ProfileParameters profileParameters, Collection<Status> status, String visibility);
 }

--- a/src/main/java/uk/gov/cslearning/catalogue/repository/CourseSearchRepository.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/CourseSearchRepository.java
@@ -2,11 +2,12 @@ package uk.gov.cslearning.catalogue.repository;
 
 import org.springframework.data.domain.Pageable;
 import uk.gov.cslearning.catalogue.api.FilterParameters;
+import uk.gov.cslearning.catalogue.api.ProfileParameters;
 import uk.gov.cslearning.catalogue.domain.SearchPage;
 import uk.gov.cslearning.catalogue.domain.Status;
 
 import java.util.Collection;
 
 public interface CourseSearchRepository {
-    SearchPage search(String query, Pageable pageable, FilterParameters filterParameters, Collection<Status> status);
+    SearchPage search(String query, Pageable pageable, FilterParameters filterParameters, ProfileParameters profileParameters, Collection<Status> status);
 }

--- a/src/main/java/uk/gov/cslearning/catalogue/repository/CourseSearchRepositoryImpl.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/CourseSearchRepositoryImpl.java
@@ -88,8 +88,12 @@ public class CourseSearchRepositoryImpl implements CourseSearchRepository {
 
         boolQuery = addFilter(boolQuery, statusList, "status");
 
+        BoolQueryBuilder filterQuery = boolQuery();
+        filterQuery.mustNot(QueryBuilders.matchQuery("course.visibility", "PRIVATE"));
+
         SearchQuery searchQuery = new NativeSearchQueryBuilder()
                 .withQuery(boolQuery)
+                .withFilter(filterQuery)
                 .withSort(SortBuilders.scoreSort().order(SortOrder.DESC))
                 .withPageable(pageable)
                 .build();

--- a/src/main/java/uk/gov/cslearning/catalogue/repository/CourseSearchRepositoryImpl.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/CourseSearchRepositoryImpl.java
@@ -37,9 +37,9 @@ public class CourseSearchRepositoryImpl implements CourseSearchRepository {
     }
 
     @Override
-    public SearchPage search(String query, Pageable pageable, FilterParameters filterParameters, ProfileParameters profileParameters, Collection<Status> statusCollection) {
+    public SearchPage search(String query, Pageable pageable, FilterParameters filterParameters, ProfileParameters profileParameters, Collection<Status> statusCollection, String visibility) {
 
-        Page<Course> coursePage = executeSearchQuery(query, pageable, filterParameters, profileParameters, statusCollection);
+        Page<Course> coursePage = executeSearchQuery(query, pageable, filterParameters, profileParameters, statusCollection, visibility);
 
         SearchPage searchPage = new SearchPage();
         searchPage.setCourses(coursePage);
@@ -47,7 +47,7 @@ public class CourseSearchRepositoryImpl implements CourseSearchRepository {
         return searchPage;
     }
 
-    private Page<Course> executeSearchQuery(String query, Pageable pageable, FilterParameters filterParameters, ProfileParameters profileParameters, Collection<Status> statusCollection) {
+    private Page<Course> executeSearchQuery(String query, Pageable pageable, FilterParameters filterParameters, ProfileParameters profileParameters, Collection<Status> statusCollection, String visibility) {
 
         BoolQueryBuilder boolQuery = boolQuery();
 
@@ -90,7 +90,10 @@ public class CourseSearchRepositoryImpl implements CourseSearchRepository {
         boolQuery = addFilter(boolQuery, statusList, "status");
 
         BoolQueryBuilder filterQuery = boolQuery();
-        filterQuery.should(QueryBuilders.matchQuery("visibility", "PUBLIC"));
+
+        if(visibility.equals("PUBLIC")) {
+            filterQuery.should(QueryBuilders.matchQuery("visibility", "PUBLIC"));
+        }
 
         addOrFilter(filterQuery, profileParameters.getProfileDepartments(), "audiences.departments");
         addOrFilter(filterQuery, profileParameters.getProfileGrades(), "audiences.grades");

--- a/src/main/java/uk/gov/cslearning/catalogue/repository/CourseSearchRepositoryImpl.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/CourseSearchRepositoryImpl.java
@@ -3,7 +3,6 @@ package uk.gov.cslearning.catalogue.repository;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
-import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
@@ -93,16 +92,10 @@ public class CourseSearchRepositoryImpl implements CourseSearchRepository {
         BoolQueryBuilder filterQuery = boolQuery();
         filterQuery.should(QueryBuilders.matchQuery("visibility", "PUBLIC"));
 
-
-
-        if (profileParameters.getProfileDepartment() != null) {
-            filterQuery.should(QueryBuilders.matchQuery("audiences.departments", profileParameters.getProfileDepartment()));
-        }
-        if (profileParameters.getProfileGrade() != null) {
-            filterQuery.should(QueryBuilders.matchQuery("audiences.grades", profileParameters.getProfileGrade()));
-        }
-        addFilter(filterQuery, profileParameters.getProfileAreasOfWork(), "audiences.areasOfWork");
-        addFilter(filterQuery, profileParameters.getProfileInterests(), "audiences.interests");
+        addOrFilter(filterQuery, profileParameters.getProfileDepartments(), "audiences.departments");
+        addOrFilter(filterQuery, profileParameters.getProfileGrades(), "audiences.grades");
+        addOrFilter(filterQuery, profileParameters.getProfileAreasOfWork(), "audiences.areasOfWork");
+        addOrFilter(filterQuery, profileParameters.getProfileInterests(), "audiences.interests");
 
         SearchQuery searchQuery = new NativeSearchQueryBuilder()
                 .withQuery(boolQuery)
@@ -125,6 +118,16 @@ public class CourseSearchRepositoryImpl implements CourseSearchRepository {
             filterQuery.minimumShouldMatch(1);
             return boolQuery.must(filterQuery);
         }
+        return boolQuery;
+    }
+
+    private BoolQueryBuilder addOrFilter(BoolQueryBuilder boolQuery, List<String> values, String key) {
+        if (values != null && !values.isEmpty()) {
+            for(String value : values) {
+                boolQuery.should(QueryBuilders.matchQuery(key, value));
+            }
+        }
+
         return boolQuery;
     }
 }

--- a/src/test/java/uk/gov/cslearning/catalogue/api/SearchControllerTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/api/SearchControllerTest.java
@@ -51,7 +51,7 @@ public class SearchControllerTest {
         searchPage.setTopScoringSuggestion(suggestion);
         searchPage.setCourses(coursePage);
 
-        when(courseRepository.search(any(String.class), any(Pageable.class), any(FilterParameters.class), any(ProfileParameters.class), any(Collection.class)))
+        when(courseRepository.search(any(String.class), any(Pageable.class), any(FilterParameters.class), any(ProfileParameters.class), any(Collection.class), any(String.class)))
                 .thenReturn(searchPage);
 
         mockMvc.perform(

--- a/src/test/java/uk/gov/cslearning/catalogue/api/SearchControllerTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/api/SearchControllerTest.java
@@ -51,7 +51,7 @@ public class SearchControllerTest {
         searchPage.setTopScoringSuggestion(suggestion);
         searchPage.setCourses(coursePage);
 
-        when(courseRepository.search(any(String.class), any(Pageable.class), any(FilterParameters.class), any(Collection.class)))
+        when(courseRepository.search(any(String.class), any(Pageable.class), any(FilterParameters.class), any(ProfileParameters.class), any(Collection.class)))
                 .thenReturn(searchPage);
 
         mockMvc.perform(

--- a/src/test/java/uk/gov/cslearning/catalogue/repository/CourseRepositoryIT.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/repository/CourseRepositoryIT.java
@@ -190,7 +190,7 @@
 //            audience.setDepartments(ImmutableSet.of(department));
 //        }
 //        if (areaOfWork != null) {
-//            audience.setAreasOfWork(ImmutableSet.of(areaOfWork));
+//            audience.setProfileAreasOfWork(ImmutableSet.of(areaOfWork));
 //        }
 //        audience.setMandatory(mandatory);
 //

--- a/src/test/java/uk/gov/cslearning/catalogue/repository/CourseSearchRepositoryIT.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/repository/CourseSearchRepositoryIT.java
@@ -43,7 +43,7 @@ public class CourseSearchRepositoryIT {
         Collection<Status> statusCollection = new ArrayList();
         statusCollection.add(Status.PUBLISHED);
 
-        SearchPage actualSearchPage = repository.search("Wirking with Budgets", pageable, filterParameters, profileParameters, statusCollection);
+        SearchPage actualSearchPage = repository.search("Wirking with Budgets", pageable, filterParameters, profileParameters, statusCollection, "PUBLIC");
 
         String actualSuggestionText = actualSearchPage.getTopScoringSuggestion().getText().toString();
         Page<Course> resourcePage = actualSearchPage.getCourses();
@@ -63,7 +63,7 @@ public class CourseSearchRepositoryIT {
         Collection<Status> statusCollection = new ArrayList();
         statusCollection.add(Status.PUBLISHED);
 
-        SearchPage actualSearchPage = repository.search("Budgets", pageable, filterParameters, profileParameters, statusCollection);
+        SearchPage actualSearchPage = repository.search("Budgets", pageable, filterParameters, profileParameters, statusCollection, "PUBLIC");
         List<Course> actualResources = actualSearchPage.getCourses().getContent();
 
         assertThat(actualResources.size(), is(2));
@@ -80,7 +80,7 @@ public class CourseSearchRepositoryIT {
         Collection<Status> statusCollection = new ArrayList();
         statusCollection.add(Status.PUBLISHED);
 
-        SearchPage actualSearchPage = repository.search("Spotify engineering culture: part 1", pageable, filterParameters, profileParameters, statusCollection);
+        SearchPage actualSearchPage = repository.search("Spotify engineering culture: part 1", pageable, filterParameters, profileParameters, statusCollection, "PUBLIC");
         List<Course> actualResources = actualSearchPage.getCourses().getContent();
 
         assertThat(actualResources.get(0).getTitle(), is("Spotify engineering culture: part 1"));
@@ -97,7 +97,7 @@ public class CourseSearchRepositoryIT {
         Collection<Status> statusCollection = new ArrayList();
         statusCollection.add(Status.PUBLISHED);
 
-        SearchPage actualSearchPage = repository.search("why", pageable, filterParameters, profileParameters, statusCollection);
+        SearchPage actualSearchPage = repository.search("why", pageable, filterParameters, profileParameters, statusCollection, "PUBLIC");
         List<Course> actualResources = actualSearchPage.getCourses().getContent();
 
         assertThat(actualResources.get(0).getTitle(), is("Understanding and using business cases"));

--- a/src/test/java/uk/gov/cslearning/catalogue/repository/CourseSearchRepositoryIT.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/repository/CourseSearchRepositoryIT.java
@@ -7,8 +7,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.junit4.SpringRunner;
+import sun.java2d.cmm.Profile;
 import uk.gov.cslearning.catalogue.api.FilterParameters;
 import uk.gov.cslearning.catalogue.api.PageParameters;
+import uk.gov.cslearning.catalogue.api.ProfileParameters;
 import uk.gov.cslearning.catalogue.domain.Course;
 import uk.gov.cslearning.catalogue.domain.SearchPage;
 import uk.gov.cslearning.catalogue.domain.Status;
@@ -36,11 +38,12 @@ public class CourseSearchRepositoryIT {
     public void shouldReturnAccurateSuggestionAndResourceWithMisspelledSearchQuery() {
         PageParameters pageParameters = new PageParameters();
         FilterParameters filterParameters = new FilterParameters();
+        ProfileParameters profileParameters = new ProfileParameters();
         Pageable pageable = pageParameters.getPageRequest();
         Collection<Status> statusCollection = new ArrayList();
         statusCollection.add(Status.PUBLISHED);
 
-        SearchPage actualSearchPage = repository.search("Wirking with Budgets", pageable, filterParameters, statusCollection);
+        SearchPage actualSearchPage = repository.search("Wirking with Budgets", pageable, filterParameters, profileParameters, statusCollection);
 
         String actualSuggestionText = actualSearchPage.getTopScoringSuggestion().getText().toString();
         Page<Course> resourcePage = actualSearchPage.getCourses();
@@ -56,10 +59,11 @@ public class CourseSearchRepositoryIT {
         PageParameters pageParameters = new PageParameters();
         Pageable pageable = pageParameters.getPageRequest();
         FilterParameters filterParameters = new FilterParameters();
+        ProfileParameters profileParameters = new ProfileParameters();
         Collection<Status> statusCollection = new ArrayList();
         statusCollection.add(Status.PUBLISHED);
 
-        SearchPage actualSearchPage = repository.search("Budgets", pageable, filterParameters, statusCollection);
+        SearchPage actualSearchPage = repository.search("Budgets", pageable, filterParameters, profileParameters, statusCollection);
         List<Course> actualResources = actualSearchPage.getCourses().getContent();
 
         assertThat(actualResources.size(), is(2));
@@ -72,10 +76,11 @@ public class CourseSearchRepositoryIT {
         PageParameters pageParameters = new PageParameters();
         Pageable pageable = pageParameters.getPageRequest();
         FilterParameters filterParameters = new FilterParameters();
+        ProfileParameters profileParameters = new ProfileParameters();
         Collection<Status> statusCollection = new ArrayList();
         statusCollection.add(Status.PUBLISHED);
 
-        SearchPage actualSearchPage = repository.search("Spotify engineering culture: part 1", pageable, filterParameters, statusCollection);
+        SearchPage actualSearchPage = repository.search("Spotify engineering culture: part 1", pageable, filterParameters, profileParameters, statusCollection);
         List<Course> actualResources = actualSearchPage.getCourses().getContent();
 
         assertThat(actualResources.get(0).getTitle(), is("Spotify engineering culture: part 1"));
@@ -87,11 +92,12 @@ public class CourseSearchRepositoryIT {
         PageParameters pageParameters = new PageParameters();
         Pageable pageable = pageParameters.getPageRequest();
         FilterParameters filterParameters = new FilterParameters();
+        ProfileParameters profileParameters = new ProfileParameters();
         filterParameters.setTypes(asList("face to face"));
         Collection<Status> statusCollection = new ArrayList();
         statusCollection.add(Status.PUBLISHED);
 
-        SearchPage actualSearchPage = repository.search("why", pageable, filterParameters, statusCollection);
+        SearchPage actualSearchPage = repository.search("why", pageable, filterParameters, profileParameters, statusCollection);
         List<Course> actualResources = actualSearchPage.getCourses().getContent();
 
         assertThat(actualResources.get(0).getTitle(), is("Understanding and using business cases"));


### PR DESCRIPTION
This stops private courses from being searchable to learners who are not in the courses audience. Unless the search is sent from management, in which case a visibility flag is passed and the visibility of the course is ignored in the search.

- Create **ProfileParameters.java**
- Added visibility flag and profileParameters to search endpoint in **SearchController.java**
- Added filter to query in **CourseRepositoryImpl.java** to only return public courses or course with audiences that match the learners profile, or any course if the search comes from management
- Updated **CourseRepository.java** and **CourseSearchRepositstory** accordingly
