### PR TITLE
LC-102: updating query to phrase search

### DIFF
--- a/src/main/java/uk/gov/cslearning/catalogue/repository/CourseSearchRepositoryImpl.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/CourseSearchRepositoryImpl.java
@@ -170,7 +170,7 @@ public class CourseSearchRepositoryImpl implements CourseSearchRepository {
 
             for (String department : values) {
                 filterQuery = filterQuery
-                        .should(QueryBuilders.matchQuery(key, department));
+                        .should(QueryBuilders.matchPhraseQuery(key, department));
             }
             filterQuery.minimumShouldMatch(1);
             return boolQuery.must(filterQuery);
@@ -181,7 +181,7 @@ public class CourseSearchRepositoryImpl implements CourseSearchRepository {
     private BoolQueryBuilder addOrFilter(BoolQueryBuilder boolQuery, List<String> values, String key) {
         if (values != null && !values.isEmpty()) {
             for (String value : values) {
-                boolQuery.should(QueryBuilders.matchQuery(key, value));
+                boolQuery.should(QueryBuilders.matchPhraseQuery(key, value));
             }
         }
 

--- a/src/main/java/uk/gov/cslearning/catalogue/repository/CourseSuggestionsRepositoryImpl.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/CourseSuggestionsRepositoryImpl.java
@@ -28,9 +28,9 @@ public class CourseSuggestionsRepositoryImpl implements CourseSuggestionsReposit
     public Page<Course> findSuggested(String department, String areaOfWork, String interest, String status, Pageable pageable) {
         BoolQueryBuilder boolQuery = boolQuery();
 
-        boolQuery.should(QueryBuilders.matchQuery("audiences.departments", department));
-        boolQuery.should(QueryBuilders.matchQuery("audiences.areasOfWork", areaOfWork));
-        boolQuery.should(QueryBuilders.matchQuery("audiences.interests", interest));
+        boolQuery.should(QueryBuilders.matchPhraseQuery("audiences.departments", department));
+        boolQuery.should(QueryBuilders.matchPhraseQuery("audiences.areasOfWork", areaOfWork));
+        boolQuery.should(QueryBuilders.matchPhraseQuery("audiences.interests", interest));
 
         BoolQueryBuilder filterQuery = boolQuery();
         filterQuery.mustNot(QueryBuilders.matchQuery("audiences.type", "REQUIRED_LEARNING"));


### PR DESCRIPTION
- search filters such as interests were searching by query
- this meant 'EU and international' and 'Parliament and the constitution' were returning the same results due to searching on the word 'and'
- updating query for search filters to matchPhrase query