### PR TITLE
LC-269: adding new post method for getIds

### DIFF
--- a/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
@@ -191,6 +191,15 @@ public class CourseController {
         return new ResponseEntity<>(result, OK);
     }
 
+
+    @PostMapping(value = "/getIds")
+    public ResponseEntity<Iterable<Course>> getId(@RequestBody List<String> courseIds) {
+        LOGGER.debug("Getting courses with IDs {}", courseIds);
+        Iterable<Course> result = courseRepository.findAllById(courseIds);
+        return new ResponseEntity<>(result, OK);
+    }
+
+
     @GetMapping("/{courseId}")
     public ResponseEntity<Course> get(@PathVariable("courseId") String courseId) {
         LOGGER.debug("Getting course with ID {}", courseId);

--- a/src/test/java/uk/gov/cslearning/catalogue/api/CourseControllerTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/api/CourseControllerTest.java
@@ -419,6 +419,22 @@ public class CourseControllerTest {
                 .andExpect(jsonPath("$.title", equalTo("title")));
     }
 
+    @Test
+    public void shouldReturnCoursesByIds() throws Exception {
+        List<String> courses = Arrays.asList("1");
+        Iterable<Course> result = new ArrayList<>();
+
+        when(courseRepository.findAllById(courses))
+                .thenReturn(result);
+
+        mockMvc.perform(
+                post("/courses/getIds").with(csrf())
+                        .content(objectMapper.writeValueAsString(courses))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
 
     @Test
     public void shouldUpdateExistingCourse() throws Exception {


### PR DESCRIPTION
- adding new endpoint for getting course ids via post instead of request params

https://cshrdigitalandanalysis.atlassian.net/browse/LC-269