### PR TITLE
Only courses with required date and correct department are fetched.

### DIFF
--- a/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
@@ -126,8 +126,8 @@ public class CourseController {
         List<String> organisationParents = courseService.getOrganisationParents(department);
 
         List<Course> courses = new ArrayList<>();
-        for (String d : organisationParents) {
-            courses.addAll(courseRepository.findMandatory(d, status, pageable));
+        for (String parent : organisationParents) {
+            courses.addAll(courseService.fetchMandatoryCourses(status, parent, pageable));
         }
 
         Set<String> courseSet = new HashSet<>();

--- a/src/main/java/uk/gov/cslearning/catalogue/repository/CourseRepository.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/CourseRepository.java
@@ -18,8 +18,8 @@ import java.util.List;
 @Repository
 public interface CourseRepository extends ElasticsearchRepository<Course, String>, CourseSearchRepository, CourseSuggestionsRepository {
 
-    @Query("{\"bool\": {\"must\": [{\"match\": {\"audiences.type\": \"REQUIRED_LEARNING\"}},{\"match\": {\"status\": \"?1\"}},{\"match\": {\"audiences.departments\": \"?0\"}}]}}")
-    List<Course> findMandatory(String department, String status, Pageable pageable);
+    @Query("{\"bool\": {\"must\": [{\"match\": {\"audiences.type\": \"REQUIRED_LEARNING\"}},{\"match\": {\"status\": \"?0\"}}]}}")
+    List<Course> findMandatory(String status, Pageable pageable);
 
     @Query("{\"bool\": {\"must\": [{\"match\": {\"audiences.type\": \"REQUIRED_LEARNING\"}},{\"match\": {\"status\": \"?1\"}},{\"match\": {\"audiences.departments\": \"[?0]\"}}]}}")
     List<Course> findMandatoryOfMultipleDepts(List<String> department, String status, Pageable pageable);

--- a/src/main/java/uk/gov/cslearning/catalogue/repository/CourseRepository.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/CourseRepository.java
@@ -19,7 +19,7 @@ import java.util.List;
 public interface CourseRepository extends ElasticsearchRepository<Course, String>, CourseSearchRepository, CourseSuggestionsRepository {
 
     @Query("{\"bool\": {\"must\": [{\"match\": {\"audiences.type\": \"REQUIRED_LEARNING\"}},{\"match\": {\"status\": \"?0\"}}]}}")
-    List<Course> findMandatory(String status, Pageable pageable);
+    List<Course> findAllRequiredLearning(String status, Pageable pageable);
 
     @Query("{\"bool\": {\"must\": [{\"match\": {\"audiences.type\": \"REQUIRED_LEARNING\"}},{\"match\": {\"status\": \"?1\"}},{\"match\": {\"audiences.departments\": \"[?0]\"}}]}}")
     List<Course> findMandatoryOfMultipleDepts(List<String> department, String status, Pageable pageable);

--- a/src/main/java/uk/gov/cslearning/catalogue/service/CourseService.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/CourseService.java
@@ -140,7 +140,7 @@ public class CourseService {
     public List<Course> fetchMandatoryCourses(String status, String department, Pageable pageable) { ;
         Set<Course> mandatoryCoursesWithValidAudience = new HashSet<>();
 
-        courseRepository.findMandatory(status, pageable)
+        courseRepository.findAllRequiredLearning(status, pageable)
             .forEach(course -> course.getAudiences()
                 .forEach(audience -> addCourseIfAudienceIsRequired(course, audience, department, mandatoryCoursesWithValidAudience)));
 

--- a/src/test/java/uk/gov/cslearning/catalogue/service/CourseServiceTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/service/CourseServiceTest.java
@@ -400,13 +400,43 @@ public class CourseServiceTest {
         course3.setAudiences(prepareAudiences(TEST_DEPARTMENT_2, Instant.now()));
         courses.add(course3);
 
-        when(courseRepository.findMandatory(eq(Status.PUBLISHED.getValue()), eq(PAGEABLE))).thenReturn(courses);
+        when(courseRepository.findAllRequiredLearning(eq(Status.PUBLISHED.getValue()), eq(PAGEABLE))).thenReturn(courses);
 
         List<Course> mandatoryCourses = courseService.fetchMandatoryCourses(Status.PUBLISHED.getValue(), TEST_DEPARTMENT_1, PAGEABLE);
 
         assertEquals(mandatoryCourses.size(), 1);
         assertEquals(mandatoryCourses.get(0).getId(), COURSE_ID_2);
         assertEquals(mandatoryCourses.get(0).getAudiences().size(), 1);
+    }
+
+    @Test
+    public void shouldNotThrowNullPointerExceptionsWhenFilteringCourses() {
+        List<Course> courses = new ArrayList<>();
+
+        Course course1 = new Course();
+        course1.setId(COURSE_ID_1);
+        course1.setAudiences(prepareAudiences(null, null));
+        courses.add(course1);
+
+        Course course2 = new Course();
+        course2.setId(COURSE_ID_2);
+        course2.setAudiences(null);
+        courses.add(course2);
+
+        Course course3 = new Course();
+        course3.setId(COURSE_ID_3);
+        Audience audience = new Audience();
+        audience.setDepartments(null);
+        Set<Audience> audiences = new HashSet<>();
+        audiences.add(audience);
+        course3.setAudiences(audiences);
+        courses.add(course3);
+
+        when(courseRepository.findAllRequiredLearning(eq(Status.PUBLISHED.getValue()), eq(PAGEABLE))).thenReturn(courses);
+
+        List<Course> mandatoryCourses = courseService.fetchMandatoryCourses(Status.PUBLISHED.getValue(), TEST_DEPARTMENT_1, PAGEABLE);
+
+        assertEquals(mandatoryCourses.size(), 0);
     }
 
     private Set<Audience> prepareAudiences(String departmentName, Instant requiredBy) {


### PR DESCRIPTION
Find mandatory method changed to fetch only courses with audiences with required status. Then they are filtered and checked if they both have required by date and correct department, both parent and regular.