### PR TITLE
Idt feature lc 1545 remove dep hierarchy

### DIFF
--- a/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
@@ -252,18 +252,12 @@ public class CourseController {
     }
 
     Course getMandatoryCourseForDepartments(Course course, List<String> departments) {
-        Optional<Audience> relevantAudience = course
-                .getAudiences()
-                .stream()
-                .filter(audience -> audience.isRequiredForDepartments(departments))
-                .min(Comparator.comparing(Audience::getRequiredBy).thenComparing(Audience::getId));
+        List<Audience> relevantAudiences = course.getMandatoryAudiencesForDepartments(departments);
 
         Course mandatoryCourse = null;
-        if (relevantAudience.isPresent()) {
-            Audience audience = relevantAudience.get();
+        if (!relevantAudiences.isEmpty()) {
             mandatoryCourse = course;
-            Set<Audience> audiences = new HashSet<>();
-            audiences.add(audience);
+            Set<Audience> audiences = new HashSet<>(relevantAudiences);
             mandatoryCourse.setAudiences(audiences);
         }
 

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/Course.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/Course.java
@@ -1,5 +1,6 @@
 package uk.gov.cslearning.catalogue.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.elasticsearch.common.UUIDs;
 import org.springframework.data.annotation.Id;
@@ -11,6 +12,7 @@ import uk.gov.cslearning.catalogue.domain.module.Module;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableSet;
@@ -59,6 +61,14 @@ public class Course {
         this.shortDescription = shortDescription;
         this.description = description;
         this.visibility = visibility;
+    }
+
+    @JsonIgnore
+    public List<Audience> getMandatoryAudiencesForDepartments(List<String> departmentCodes) {
+        return getAudiences()
+                .stream()
+                .filter(audience -> audience.isRequiredForDepartments(departmentCodes))
+                .collect(Collectors.toList());
     }
 
     public List<Module> getModules() {

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/Audience.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/Audience.java
@@ -1,5 +1,6 @@
 package uk.gov.cslearning.catalogue.domain.module;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import org.elasticsearch.common.UUIDs;
 
@@ -40,10 +41,12 @@ public class Audience {
     public Audience() {
     }
 
+    @JsonIgnore
     public boolean isRequired() {
         return type.equals(Type.REQUIRED_LEARNING) && requiredBy != null;
     }
 
+    @JsonIgnore
     public boolean isRequiredForDepartments(List<String> departments) {
         return this.isRequired() && departments.stream().anyMatch(departmentCode -> this.getDepartments().contains(departmentCode));
     }

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/Audience.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/Audience.java
@@ -5,6 +5,7 @@ import org.elasticsearch.common.UUIDs;
 
 import java.time.Instant;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Data
@@ -37,5 +38,13 @@ public class Audience {
     private String eventId;
 
     public Audience() {
+    }
+
+    public boolean isRequired() {
+        return type.equals(Type.REQUIRED_LEARNING) && requiredBy != null;
+    }
+
+    public boolean isRequiredForDepartments(List<String> departments) {
+        return this.isRequired() && departments.stream().anyMatch(departmentCode -> this.getDepartments().contains(departmentCode));
     }
 }


### PR DESCRIPTION
- Remove dependancy on the CSRS API to get the organisation hierarchy for required learniing.
    - Departments are now supplied as a generic list parameter, with any relevant courses/audiences being returned 