### PR TITLE
LC 1752 allow upload of other ELearning formats

### DIFF
--- a/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
@@ -395,7 +395,7 @@ public class CourseController {
     @PostMapping("/{courseId}/modules")
     @PreAuthorize("(hasPermission(#courseId, 'write') and hasAnyAuthority(T(uk.gov.cslearning.catalogue.domain.Roles).LEARNING_CREATE, T(uk.gov.cslearning.catalogue.domain.Roles).LEARNING_MANAGER, T(uk.gov.cslearning.catalogue.domain.Roles).CSL_AUTHOR))")
     public ResponseEntity<Void> createModule(@PathVariable String courseId, @RequestBody Module module, UriComponentsBuilder builder) {
-        LOGGER.debug("Adding module to course with ID {}", courseId);
+        LOGGER.info("Adding module to course with ID {}", courseId);
 
         Module saved = moduleService.save(courseId, module);
 

--- a/src/main/java/uk/gov/cslearning/catalogue/config/RusticiConfig.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/config/RusticiConfig.java
@@ -22,12 +22,12 @@ public class RusticiConfig {
     @Value("${rustici.tenant}")
     private String rusticiTenant;
 
-    @Value("${azure.content-cdn}")
-    private String contentCdn;
+    @Value("${azure.scorm-cdn}")
+    private String scormCdn;
 
     @Bean()
     public CSLToRusticiDataService getDataTranslationService() {
-        return new CSLToRusticiDataService(contentCdn);
+        return new CSLToRusticiDataService(scormCdn);
     }
 
     @Bean("rusticiHttpClient")

--- a/src/main/java/uk/gov/cslearning/catalogue/config/UploadConfig.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/config/UploadConfig.java
@@ -56,7 +56,7 @@ public class UploadConfig {
     }
 
     @Bean(name = "elearning_manifest_list")
-    public List<String> getElearningManifests(@Value("rustici.e-learning-manifests") String eLearningManifestsCsv) {
+    public List<String> getElearningManifests(@Value("${rustici.e-learning-manifests}") String eLearningManifestsCsv) {
         return Arrays.asList(eLearningManifestsCsv.split(","));
     }
 

--- a/src/main/java/uk/gov/cslearning/catalogue/config/UploadConfig.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/config/UploadConfig.java
@@ -14,13 +14,15 @@ import uk.gov.cslearning.catalogue.service.upload.client.AzureUploadClient;
 import uk.gov.cslearning.catalogue.service.upload.client.UploadClient;
 
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @Slf4j
 public class UploadConfig {
 
     @Bean(name = "learning_material")
-    public UploadClient scormAzureUploadClient(CloudBlobClient client, @Value("${azure.storage.rustici-container}") String containerName) {
+    public UploadClient scormAzureUploadClient(CloudBlobClient client, @Value("${azure.storage.scorm-container}") String containerName) {
         CloudBlobContainer container = createBlobContainer(client, containerName);
         return new AzureUploadClient(container);
     }
@@ -51,6 +53,11 @@ public class UploadConfig {
     @Bean
     public Tika tika() {
         return new Tika();
+    }
+
+    @Bean(name = "elearning_manifest_list")
+    public List<String> getElearningManifests(@Value("rustici.e-learning-manifests") String eLearningManifestsCsv) {
+        return Arrays.asList(eLearningManifestsCsv.split(","));
     }
 
 }

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/CustomMediaMetadata.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/CustomMediaMetadata.java
@@ -1,0 +1,16 @@
+package uk.gov.cslearning.catalogue.domain;
+
+public enum CustomMediaMetadata {
+
+    ELEARNING_MANIFEST("elearning_manifest");
+
+    private final String metadataKey;
+
+    CustomMediaMetadata(String metadataKey) {
+        this.metadataKey = metadataKey;
+    }
+
+    public String getMetadataKey() {
+        return metadataKey;
+    }
+}

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/Media.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/Media.java
@@ -1,5 +1,6 @@
 package uk.gov.cslearning.catalogue.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
@@ -31,7 +32,7 @@ public class Media {
     @NotNull
     private String path;
 
-    private Map<String, Object> metadata = new HashMap<>();
+    private Map<String, String> metadata = new HashMap<>();
 
     private long fileSizeKB;
     private String extension;
@@ -101,11 +102,16 @@ public class Media {
         this.path = path;
     }
 
-    public Map<String, Object> getMetadata() {
+    public Map<String, String> getMetadata() {
         return metadata;
     }
 
-    public void setMetadata(Map<String, Object> metadata) {
+    public void setMetadata(Map<String, String> metadata) {
         this.metadata = metadata;
+    }
+
+    @JsonIgnore
+    public String getMetadataWithCustomKey(CustomMediaMetadata key) {
+        return this.metadata.get(key.getMetadataKey());
     }
 }

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/MediaFactory.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/MediaFactory.java
@@ -6,8 +6,6 @@ import uk.gov.cslearning.catalogue.dto.upload.Upload;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Component
 public class MediaFactory {
@@ -27,9 +25,7 @@ public class MediaFactory {
         }
         media.setPath(path);
         media.setFileSizeKB(upload.getSizeKB());
-        Map<String, Object> convertedMap = processedFileUpload.getMetadata()
-                .entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-        media.setMetadata(convertedMap);
+        media.setMetadata(processedFileUpload.getMetadata());
 
         return media;
 

--- a/src/main/java/uk/gov/cslearning/catalogue/service/rustici/CSLToRusticiDataService.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/rustici/CSLToRusticiDataService.java
@@ -11,9 +11,9 @@ public class CSLToRusticiDataService {
         this.cdnEndpoint = cdnEndpoint;
     }
 
-    public CreateCourse getCreateCourseData(String courseId, String mediaId) {
+    public CreateCourse getCreateCourseData(String courseId, String mediaId, String manifestFile) {
         String ELearningCdnLocation = getRusticiCourseCdnLocation(courseId, mediaId);
-        String imsManifestUrl = String.format("%s/imsmanifest.xml", ELearningCdnLocation);
+        String imsManifestUrl = String.format("%s/%s", ELearningCdnLocation, manifestFile);
         return CreateCourse.createFromData(
                 ELearningCdnLocation,
                 imsManifestUrl);

--- a/src/main/java/uk/gov/cslearning/catalogue/service/rustici/CSLToRusticiDataService.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/rustici/CSLToRusticiDataService.java
@@ -12,10 +12,10 @@ public class CSLToRusticiDataService {
     }
 
     public CreateCourse getCreateCourseData(String courseId, String mediaId, String manifestFile) {
-        String ELearningCdnLocation = getRusticiCourseCdnLocation(courseId, mediaId);
-        String imsManifestUrl = String.format("%s/%s", ELearningCdnLocation, manifestFile);
+        String eLearningCdnLocation = getRusticiCourseCdnLocation(courseId, mediaId);
+        String imsManifestUrl = String.format("%s/%s", eLearningCdnLocation, manifestFile);
         return CreateCourse.createFromData(
-                ELearningCdnLocation,
+                eLearningCdnLocation,
                 imsManifestUrl);
     }
 

--- a/src/main/java/uk/gov/cslearning/catalogue/service/rustici/RusticiEngineService.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/rustici/RusticiEngineService.java
@@ -2,25 +2,38 @@ package uk.gov.cslearning.catalogue.service.rustici;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import uk.gov.cslearning.catalogue.domain.CustomMediaMetadata;
+import uk.gov.cslearning.catalogue.domain.Media;
 import uk.gov.cslearning.catalogue.dto.rustici.course.Course;
 import uk.gov.cslearning.catalogue.dto.rustici.course.CreateCourse;
 import uk.gov.cslearning.catalogue.dto.rustici.course.CreateCourseResponse;
+import uk.gov.cslearning.catalogue.exception.InvalidScormException;
+import uk.gov.cslearning.catalogue.exception.ResourceNotFoundException;
+import uk.gov.cslearning.catalogue.repository.MediaRepository;
 
 @Service
 @Slf4j
 public class RusticiEngineService {
+    private final MediaRepository mediaRepository;
     private final CSLToRusticiDataService rusticiDataService;
     private final RusticiEngineClient rusticiEngineClient;
 
     public RusticiEngineService(
+            MediaRepository mediaRepository,
             CSLToRusticiDataService rusticiDataService,
             RusticiEngineClient rusticiEngineClient) {
+        this.mediaRepository = mediaRepository;
         this.rusticiDataService = rusticiDataService;
         this.rusticiEngineClient = rusticiEngineClient;
     }
 
     public void uploadElearningModule(String courseId, String moduleId, String mediaId) {
-        CreateCourse data = rusticiDataService.getCreateCourseData(courseId, mediaId);
+        Media media = mediaRepository.findById(mediaId).orElseThrow(ResourceNotFoundException::resourceNotFoundException);
+        String manifestFile = media.getMetadataWithCustomKey(CustomMediaMetadata.ELEARNING_MANIFEST);
+        if (manifestFile == null) {
+            throw new InvalidScormException(String.format("ELearning media with ID %s does now have a valid manifest metadata tag", mediaId));
+        }
+        CreateCourse data = rusticiDataService.getCreateCourseData(courseId, mediaId, manifestFile);
         String rusticiCourseId = rusticiDataService.getRusticiCourseId(courseId, moduleId);
         CreateCourseResponse createCourseResponse = rusticiEngineClient.createCourse(data, rusticiCourseId);
         if (!createCourseResponse.getParserWarnings().isEmpty()) {

--- a/src/main/java/uk/gov/cslearning/catalogue/service/upload/processor/ELearningManifestService.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/upload/processor/ELearningManifestService.java
@@ -1,0 +1,38 @@
+package uk.gov.cslearning.catalogue.service.upload.processor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class ELearningManifestService {
+
+    /**
+     * This list should be given in order of preference - with the preferred manifest being at position 0.
+     * This means that if a package has multiple manifest files, we can predictably pick a preferred one to use
+     * for the import.
+     */
+    private final List<String> validManifests;
+
+    public ELearningManifestService(@Qualifier("elearning_manifest_list") List<String> validManifests) {
+        this.validManifests = validManifests;
+    }
+
+    public String fetchManifestFromFileList(List<String> filenames) {
+        List<String> availableManifests = validManifests.stream().filter(filenames::contains).collect(Collectors.toList());
+        if (availableManifests.isEmpty()) {
+            return null;
+        }
+        if (availableManifests.size() > 1) {
+            String joinedAvailableManfiests = String.join(",", availableManifests);
+            String preferredDefaultManifest = availableManifests.get(0);
+            log.info(String.format("Files contain more than one valid manifest file (%s). Picking the preferred default manifest: %s", joinedAvailableManfiests, preferredDefaultManifest));
+            return preferredDefaultManifest;
+        }
+        return availableManifests.get(0);
+    }
+}

--- a/src/main/java/uk/gov/cslearning/catalogue/service/upload/processor/ScormFileProcessor.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/upload/processor/ScormFileProcessor.java
@@ -1,7 +1,9 @@
 package uk.gov.cslearning.catalogue.service.upload.processor;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import uk.gov.cslearning.catalogue.domain.CustomMediaMetadata;
 import uk.gov.cslearning.catalogue.dto.upload.FileUpload;
 import uk.gov.cslearning.catalogue.dto.upload.ProcessedFileUpload;
 import uk.gov.cslearning.catalogue.dto.upload.UploadableFile;
@@ -12,24 +14,31 @@ import uk.gov.cslearning.catalogue.service.upload.UploadableFileFactory;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
 @Slf4j
 public class ScormFileProcessor implements FileProcessor {
 
-    private final List<String> requiredFiles = Collections.singletonList("imsmanifest.xml");
+    private final List<String> validManifests;
     private final UploadableFileFactory uploadableFileFactory;
 
-    public ScormFileProcessor(UploadableFileFactory uploadableFileFactory) {
+    public ScormFileProcessor(UploadableFileFactory uploadableFileFactory,
+                              @Qualifier("elearning_manifest_list") List<String> validManifests) {
         this.uploadableFileFactory = uploadableFileFactory;
+        this.validManifests = validManifests;
     }
 
-    private void validateMissingFiles(List<String> filenamesInZip) {
-        List<String> missingFiles = requiredFiles.stream().filter(rF -> !filenamesInZip.contains(rF)).collect(Collectors.toList());
-        if (!missingFiles.isEmpty()) {
-            throw new InvalidScormException(String.format("SCORM file is missing the following required files: %s", String.join(",", missingFiles)));
+    private String fetchManifest(List<String> filenamesInZip) {
+        List<String> manifests = validManifests.stream().filter(filenamesInZip::contains).collect(Collectors.toList());
+        if (manifests.isEmpty()) {
+            throw new InvalidScormException(String.format("SCORM file is missing a manifest. Possible manifests are: %s", String.join(",", validManifests)));
         }
+        if (manifests.size() > 1) {
+            throw new InvalidScormException(String.format("SCORM file has more than one valid manifest. Possible manifests are: %s", String.join(",", validManifests)));
+        }
+        return manifests.get(0);
     }
 
     @Override
@@ -37,11 +46,12 @@ public class ScormFileProcessor implements FileProcessor {
         List<UploadableFile> uploadableFiles;
         try {
             uploadableFiles = uploadableFileFactory.createFromZip(fileUpload);
-            validateMissingFiles(uploadableFiles.stream().map(UploadableFile::getName).collect(Collectors.toList()));
+            String manifest = fetchManifest(uploadableFiles.stream().map(UploadableFile::getName).collect(Collectors.toList()));
+            Map<String, String> metadata = Collections.singletonMap(CustomMediaMetadata.ELEARNING_MANIFEST.getMetadataKey(), manifest);
+            return new ProcessedFileUpload(fileUpload, uploadableFiles, metadata);
         } catch (IOException | InvalidScormException e) {
             log.error(String.format("Error processing SCORM package: %s", fileUpload), e);
             throw new FileProcessingException(e);
         }
-        return new ProcessedFileUpload(fileUpload, uploadableFiles);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,7 @@ elasticsearch:
   readTimeout: ${ELASTICSEARCH_READ_TIMEOUT:10000}
 
 rustici:
+  e-learning-manifests: ${ELEARNING_MANIFESTS:"imsmanifest.xml, tincan.xml"}
   url: ${RUSTICI_URL:http://csl.local/rustici/RusticiEngine/api/v2}
   username: ${RUSTICI_USERNAME:apiuser}
   password: ${RUSTICI_PASSWORD:password}
@@ -45,9 +46,9 @@ azure:
     key: ${AZURE_ACCOUNT_KEY:Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==}
   storage:
     container: ${AZURE_STORAGE_CONTAINER:lpgdevcontent}
-    rustici-container: ${AZURE_STORAGE_RUSTICI_CONTAINER:rustici}
+    scorm-container: ${AZURE_STORAGE_SCORM_CONTAINER:rustici}
     connection-string: ${AZURE_STORAGE_CONNECTION_STRING:DefaultEndpointsProtocol=http;AccountName=${azure.account.name};AccountKey=${azure.account.key};${azure.storage.blob-endpoint}}
-  content-cdn: ${AZURE_CONTENT_CDN_ENDPOINT:http://csl.local/azurite/devstoreaccount1/${azure.storage.rustici-container}}
+  scorm-cdn: ${SCORM_CDN_ENDPOINT:http://csl.local/azurite/devstoreaccount1/${azure.storage.scorm-container}}
 
 management:
   endpoints:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,7 @@ elasticsearch:
   readTimeout: ${ELASTICSEARCH_READ_TIMEOUT:10000}
 
 rustici:
-  e-learning-manifests: ${ELEARNING_MANIFESTS:"imsmanifest.xml, tincan.xml"}
+  e-learning-manifests: ${ELEARNING_MANIFESTS:imsmanifest.xml,tincan.xml}
   url: ${RUSTICI_URL:http://csl.local/rustici/RusticiEngine/api/v2}
   username: ${RUSTICI_USERNAME:apiuser}
   password: ${RUSTICI_PASSWORD:password}

--- a/src/test/java/uk/gov/cslearning/catalogue/service/rustici/CSLToRusticiDataServiceTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/service/rustici/CSLToRusticiDataServiceTest.java
@@ -19,8 +19,9 @@ public class CSLToRusticiDataServiceTest {
     public void testGetCreateCourseData() {
         String testMediaId = "testMediaID";
         String testCourseID = "testCourseID";
-        CreateCourse createCourse = cslToRusticiDataService.getCreateCourseData(testCourseID, testMediaId);
-        assertEquals("test.com/testCourseID/testMediaID/imsmanifest.xml", createCourse.getReferenceRequest().getUrl());
+        String testManifestFile = "testManifest.xml";
+        CreateCourse createCourse = cslToRusticiDataService.getCreateCourseData(testCourseID, testMediaId, testManifestFile);
+        assertEquals("test.com/testCourseID/testMediaID/testManifest.xml", createCourse.getReferenceRequest().getUrl());
         assertEquals("test.com/testCourseID/testMediaID", createCourse.getReferenceRequest().getWebPathToCourse());
     }
 

--- a/src/test/java/uk/gov/cslearning/catalogue/service/rustici/RusticiEngineServiceTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/service/rustici/RusticiEngineServiceTest.java
@@ -5,15 +5,22 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.cslearning.catalogue.domain.CustomMediaMetadata;
+import uk.gov.cslearning.catalogue.domain.Media;
 import uk.gov.cslearning.catalogue.dto.rustici.course.Course;
 import uk.gov.cslearning.catalogue.dto.rustici.course.CreateCourse;
 import uk.gov.cslearning.catalogue.dto.rustici.course.CreateCourseResponse;
+import uk.gov.cslearning.catalogue.repository.MediaRepository;
+
+import java.util.Optional;
 
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RusticiEngineServiceTest {
 
+    @Mock
+    private MediaRepository mediaRepository;
     @Mock
     private CSLToRusticiDataService rusticiDataService;
     @Mock
@@ -24,17 +31,23 @@ public class RusticiEngineServiceTest {
     private final String courseId = "courseId";
     private final String moduleId = "moduleId";
     private final String mediaId = "mediaId";
+    private final String manifestFile = "imsmanifest.xml";
 
     @Test
     public void testSuccessfullyUploadElearningModule() {
         String rusticiCourseId = String.format("%s.%s", courseId, moduleId);
+
         Course course = mock(Course.class);
         when(course.getTitle()).thenReturn("Test title");
         when(course.getCourseLearningStandard()).thenReturn("SCORM2");
         CreateCourse createCourse = mock(CreateCourse.class);
         CreateCourseResponse createCourseResponse = mock(CreateCourseResponse.class);
         when(createCourseResponse.getCourse()).thenReturn(course);
-        when(rusticiDataService.getCreateCourseData(courseId, mediaId)).thenReturn(createCourse);
+
+        Media media = mock(Media.class);
+        when(media.getMetadataWithCustomKey(CustomMediaMetadata.ELEARNING_MANIFEST)).thenReturn(manifestFile);
+        when(mediaRepository.findById(mediaId)).thenReturn(Optional.of(media));
+        when(rusticiDataService.getCreateCourseData(courseId, mediaId, manifestFile)).thenReturn(createCourse);
         when(rusticiDataService.getRusticiCourseId(courseId, moduleId)).thenReturn(rusticiCourseId);
         when(rusticiEngineClient.createCourse(createCourse, rusticiCourseId)).thenReturn(createCourseResponse);
 

--- a/src/test/java/uk/gov/cslearning/catalogue/service/upload/processor/ELearningManifestServiceTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/service/upload/processor/ELearningManifestServiceTest.java
@@ -1,0 +1,37 @@
+package uk.gov.cslearning.catalogue.service.upload.processor;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+import static org.springframework.test.util.AssertionErrors.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ELearningManifestServiceTest {
+
+    private final List<String> validManifestFiles = Arrays.asList("imsmanifest.xml", "testmanifest.xml");
+    private ELearningManifestService eLearningManifestService;
+
+    @Before
+    public void before() {
+        this.eLearningManifestService = new ELearningManifestService(validManifestFiles);
+    }
+
+    @Test
+    public void testOrderingOfDefaultManfiest() {
+        String resultingManfiest = this.eLearningManifestService.fetchManifestFromFileList(Arrays.asList("testmanifest.xml", "imsmanifest.xml"));
+        assertEquals("Manifest files do not match", resultingManfiest, "imsmanifest.xml");
+    }
+
+    @Test
+    public void testManifestIsNullIfNotFound() {
+        String resultingManfiest = this.eLearningManifestService.fetchManifestFromFileList(Collections.singletonList("notfoundmanifest.xml"));
+        assertNull("Manifest should be null", resultingManfiest);
+    }
+}

--- a/src/test/java/uk/gov/cslearning/catalogue/service/upload/processor/ScormFileProcessorTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/service/upload/processor/ScormFileProcessorTest.java
@@ -1,8 +1,8 @@
 package uk.gov.cslearning.catalogue.service.upload.processor;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.cslearning.catalogue.domain.CustomMediaMetadata;
@@ -26,13 +26,10 @@ public class ScormFileProcessorTest {
 
     @Mock
     private UploadableFileFactory uploadableFileFactory;
-    private final List<String> validManifestFiles = Arrays.asList("imsmanifest.xml", "testmanifest.xml");
+    @Mock
+    private ELearningManifestService eLearningManifestService;
+    @InjectMocks
     private ScormFileProcessor scormFileProcessor;
-
-    @Before
-    public void before() {
-        this.scormFileProcessor = new ScormFileProcessor(uploadableFileFactory, validManifestFiles);
-    }
 
     private UploadableFile generateMockUploadableFile(String filename) {
         UploadableFile uploadableFile = mock(UploadableFile.class);
@@ -48,6 +45,9 @@ public class ScormFileProcessorTest {
         uploadableFiles.add(generateMockUploadableFile("imsmanifest.xml"));
         FileUpload fileUpload = mock(FileUpload.class);
         when(uploadableFileFactory.createFromZip(fileUpload)).thenReturn(uploadableFiles);
+        when(eLearningManifestService.fetchManifestFromFileList(Arrays.asList("TestFile.txt",
+                "TestFile.txt",
+                "imsmanifest.xml"))).thenReturn("imsmanifest.xml");
         ProcessedFileUpload processedFileUpload = scormFileProcessor.process(fileUpload);
         assertEquals("File has incorrect manifest", "imsmanifest.xml", processedFileUpload.getMetadata().get(CustomMediaMetadata.ELEARNING_MANIFEST.getMetadataKey()));
         assertEquals("File upload was not stored correctly", fileUpload, processedFileUpload.getFileUpload());
@@ -62,6 +62,9 @@ public class ScormFileProcessorTest {
         uploadableFiles.add(generateMockUploadableFile("TestFile.txt"));
         FileUpload fileUpload = mock(FileUpload.class);
         when(uploadableFileFactory.createFromZip(fileUpload)).thenReturn(uploadableFiles);
+        when(eLearningManifestService.fetchManifestFromFileList(Arrays.asList("TestFile.txt",
+                "TestFile.txt",
+                "TestFile.txt"))).thenReturn(null);
         scormFileProcessor.process(fileUpload);
     }
 }

--- a/src/test/java/uk/gov/cslearning/catalogue/service/upload/processor/ScormFileProcessorTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/service/upload/processor/ScormFileProcessorTest.java
@@ -1,10 +1,11 @@
 package uk.gov.cslearning.catalogue.service.upload.processor;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.cslearning.catalogue.domain.CustomMediaMetadata;
 import uk.gov.cslearning.catalogue.dto.upload.FileUpload;
 import uk.gov.cslearning.catalogue.dto.upload.ProcessedFileUpload;
 import uk.gov.cslearning.catalogue.dto.upload.UploadableFile;
@@ -13,6 +14,7 @@ import uk.gov.cslearning.catalogue.service.upload.UploadableFileFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -24,9 +26,13 @@ public class ScormFileProcessorTest {
 
     @Mock
     private UploadableFileFactory uploadableFileFactory;
-
-    @InjectMocks
+    private final List<String> validManifestFiles = Arrays.asList("imsmanifest.xml", "testmanifest.xml");
     private ScormFileProcessor scormFileProcessor;
+
+    @Before
+    public void before() {
+        this.scormFileProcessor = new ScormFileProcessor(uploadableFileFactory, validManifestFiles);
+    }
 
     private UploadableFile generateMockUploadableFile(String filename) {
         UploadableFile uploadableFile = mock(UploadableFile.class);
@@ -43,6 +49,7 @@ public class ScormFileProcessorTest {
         FileUpload fileUpload = mock(FileUpload.class);
         when(uploadableFileFactory.createFromZip(fileUpload)).thenReturn(uploadableFiles);
         ProcessedFileUpload processedFileUpload = scormFileProcessor.process(fileUpload);
+        assertEquals("File has incorrect manifest", "imsmanifest.xml", processedFileUpload.getMetadata().get(CustomMediaMetadata.ELEARNING_MANIFEST.getMetadataKey()));
         assertEquals("File upload was not stored correctly", fileUpload, processedFileUpload.getFileUpload());
         assertEquals("Incorrect number of uploadableFiles", 3, processedFileUpload.getUploadableFiles().size());
     }


### PR DESCRIPTION
- An environment variable (csv) can now be supplied to allow other types of ELearning file to be uploaded (by manifest)
- The manifest will be attached to the media object in Elasticsearch and subsequently used to upload the course to Rustici