### PR TITLE
LC-2904: Fix module type bug

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,3 @@
-gradle
-gradlew
-gradlew.bat
-src
-*.gradle
 *.iml
 .idea
 .DS_Store

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,8 @@
+gradle
+gradlew
+gradlew.bat
+src
+*.gradle
 *.iml
 .idea
 .DS_Store

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/ELearningModule.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/ELearningModule.java
@@ -3,8 +3,10 @@ package uk.gov.cslearning.catalogue.domain.module;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.Data;
 
 @JsonTypeName("elearning")
+@Data
 public class ELearningModule extends Module {
 
     private String startPage;
@@ -14,34 +16,10 @@ public class ELearningModule extends Module {
 
     @JsonCreator
     public ELearningModule(@JsonProperty("startPage") String startPage, @JsonProperty("url") String url) {
+        setType("elearning");
         setStartPage(startPage);
         setUrl(url);
-    }
 
-    public String getStartPage() {
-        return startPage;
-    }
-
-    public void setStartPage(String startPage) {
-        this.startPage = startPage;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
-    public String getModuleType() {
-        return "elearning";
-    }
-
-    public String getMediaId() {
-        return mediaId;
-    }
-
-    public void setMediaId(String mediaId) {
-        this.mediaId = mediaId;
     }
 }
+

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/FaceToFaceModule.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/FaceToFaceModule.java
@@ -19,8 +19,10 @@ public class FaceToFaceModule extends Module {
 
     @JsonCreator
     public FaceToFaceModule(@JsonProperty("productCode") String productCode) {
+        setType("face-to-face");
         this.productCode = productCode;
         this.events = new HashSet<>();
+
     }
 
     public Event getEventById(String eventId){
@@ -52,7 +54,4 @@ public class FaceToFaceModule extends Module {
         this.productCode = productCode;
     }
 
-    public String getModuleType() {
-        return "face-to-face";
-    }
 }

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/FileModule.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/FileModule.java
@@ -13,6 +13,7 @@ public class FileModule extends Module {
 
     @JsonCreator
     public FileModule(@JsonProperty("url") String url, @JsonProperty("fileSize") Long fileSize) {
+        setType("file");
         this.url = url;
         this.fileSize = fileSize;
     }
@@ -39,9 +40,5 @@ public class FileModule extends Module {
 
     public void setMediaId(String mediaId) {
         this.mediaId = mediaId;
-    }
-
-    public String getModuleType() {
-        return "file";
     }
 }

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/LinkModule.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/LinkModule.java
@@ -16,6 +16,7 @@ public class LinkModule extends Module {
 
     @JsonCreator
     public LinkModule(@JsonProperty("url") URL url) {
+        setType("link");
         this.url = url;
     }
 
@@ -27,7 +28,4 @@ public class LinkModule extends Module {
         this.url = url;
     }
 
-    public String getModuleType() {
-        return "link";
-    }
 }

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/Module.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/Module.java
@@ -2,6 +2,8 @@ package uk.gov.cslearning.catalogue.domain.module;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import org.elasticsearch.common.UUIDs;
 import org.springframework.data.elasticsearch.annotations.Field;
 import uk.gov.cslearning.catalogue.domain.Status;
@@ -20,6 +22,7 @@ import static org.springframework.data.elasticsearch.annotations.FieldType.Date;
         @JsonSubTypes.Type(VideoModule.class),
         @JsonSubTypes.Type(FileModule.class)
 })
+@Data
 public abstract class Module {
 
     private String id = UUIDs.randomBase64UUID();
@@ -61,87 +64,5 @@ public abstract class Module {
         this.duration = duration;
         this.type = type;
     }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public boolean isOptional() {
-        return optional;
-    }
-
-    public void setOptional(boolean optional) {
-        this.optional = optional;
-    }
-
-    public Status getStatus() {
-        return status;
-    }
-
-    public void setStatus(Status status) {
-        this.status = status;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public Long getDuration() {
-        return duration;
-    }
-
-    public void setDuration(Long duration) {
-        this.duration = duration;
-    }
-
-    public BigDecimal getCost() {
-        return cost;
-    }
-
-    public void setCost(BigDecimal cost) {
-        this.cost = cost;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public boolean isAssociatedLearning() {
-        return associatedLearning;
-    }
-
-    public void setAssociatedLearning(boolean associatedLearning) {
-        this.associatedLearning = associatedLearning;
-    }
-
-    public LocalDateTime getCreatedTimestamp() {
-        return createdTimestamp;
-    }
-
-    public void setCreatedTimestamp(LocalDateTime createdTimestamp) {
-        this.createdTimestamp = createdTimestamp;
-    }
-
-    public LocalDateTime getUpdatedTimestamp() {
-        return updatedTimestamp;
-    }
-
-    public void setUpdatedTimestamp(LocalDateTime updatedTimestamp) {
-        this.updatedTimestamp = updatedTimestamp;
-    }
-
-    public abstract String getModuleType();
 
 }

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/Module.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/Module.java
@@ -2,8 +2,6 @@ package uk.gov.cslearning.catalogue.domain.module;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 import org.elasticsearch.common.UUIDs;
 import org.springframework.data.elasticsearch.annotations.Field;
 import uk.gov.cslearning.catalogue.domain.Status;
@@ -22,7 +20,6 @@ import static org.springframework.data.elasticsearch.annotations.FieldType.Date;
         @JsonSubTypes.Type(VideoModule.class),
         @JsonSubTypes.Type(FileModule.class)
 })
-@Data
 public abstract class Module {
 
     private String id = UUIDs.randomBase64UUID();
@@ -62,6 +59,94 @@ public abstract class Module {
         this.title = title;
         this.description = description;
         this.duration = duration;
+        this.type = type;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public boolean isOptional() {
+        return optional;
+    }
+
+    public void setOptional(boolean optional) {
+        this.optional = optional;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Long getDuration() {
+        return duration;
+    }
+
+    public void setDuration(Long duration) {
+        this.duration = duration;
+    }
+
+    public BigDecimal getCost() {
+        return cost;
+    }
+
+    public void setCost(BigDecimal cost) {
+        this.cost = cost;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public boolean isAssociatedLearning() {
+        return associatedLearning;
+    }
+
+    public void setAssociatedLearning(boolean associatedLearning) {
+        this.associatedLearning = associatedLearning;
+    }
+
+    public LocalDateTime getCreatedTimestamp() {
+        return createdTimestamp;
+    }
+
+    public void setCreatedTimestamp(LocalDateTime createdTimestamp) {
+        this.createdTimestamp = createdTimestamp;
+    }
+
+    public LocalDateTime getUpdatedTimestamp() {
+        return updatedTimestamp;
+    }
+
+    public void setUpdatedTimestamp(LocalDateTime updatedTimestamp) {
+        this.updatedTimestamp = updatedTimestamp;
+    }
+
+    public String getType(){
+        return this.type;
+    }
+
+    public void setType(String type){
         this.type = type;
     }
 

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/VideoModule.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/VideoModule.java
@@ -13,6 +13,7 @@ public class VideoModule extends Module {
 
     @JsonCreator
     public VideoModule(@JsonProperty("url") URL url) {
+        setType("video");
         this.url = url;
     }
 
@@ -22,9 +23,5 @@ public class VideoModule extends Module {
 
     public void setUrl(URL url) {
         this.url = url;
-    }
-
-    public String getModuleType() {
-        return "video";
     }
 }

--- a/src/main/java/uk/gov/cslearning/catalogue/dto/factory/ModuleDtoFactory.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/dto/factory/ModuleDtoFactory.java
@@ -18,7 +18,7 @@ public class ModuleDtoFactory {
         ModuleDto moduleDto = new ModuleDto();
         moduleDto.setId(module.getId());
         moduleDto.setTitle(module.getTitle());
-        moduleDto.setType(module.getModuleType());
+        moduleDto.setType(module.getType());
         moduleDto.setRequired(!module.isOptional());
         moduleDto.setCourse(courseDtoFactory.create(course));
         moduleDto.setAssociatedLearning(module.isAssociatedLearning());

--- a/src/main/java/uk/gov/cslearning/catalogue/service/EventDtoMapService.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/EventDtoMapService.java
@@ -65,7 +65,7 @@ public class EventDtoMapService {
 
     private List<FaceToFaceModule> getFaceToFaceModules(Course course) {
         return course.getModules().stream()
-                .filter(m -> m.getModuleType().equals("face-to-face"))
+                .filter(m -> m.getType().equals("face-to-face"))
                 .map(m -> (FaceToFaceModule) m)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/uk/gov/cslearning/catalogue/service/ModuleService.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/ModuleService.java
@@ -49,7 +49,7 @@ public class ModuleService {
 
     public Module save(String courseId, Module module) {
         Course course = courseService.getCourseById(courseId);
-        if (module.getModuleType().equals("elearning")) {
+        if (module.getType().equals("elearning")) {
             rusticiEngineService.uploadElearningModule(courseId, module.getId(), ((ELearningModule) module).getMediaId());
         }
         course.upsertModule(module);


### PR DESCRIPTION
This change introduces a getter and setter for the `Module` superclass, `getType` and `setType`. This helps set the `type` attribute in ElasticSearch and also removes the need for `getModuleType()`