### PR TITLE
LC-3025 de-deplicate type key in module JSON

### DIFF
--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/ELearningModule.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/ELearningModule.java
@@ -3,10 +3,8 @@ package uk.gov.cslearning.catalogue.domain.module;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import lombok.Data;
 
 @JsonTypeName("elearning")
-@Data
 public class ELearningModule extends Module {
 
     private String startPage;
@@ -16,10 +14,34 @@ public class ELearningModule extends Module {
 
     @JsonCreator
     public ELearningModule(@JsonProperty("startPage") String startPage, @JsonProperty("url") String url) {
-        setType("elearning");
-        setStartPage(startPage);
-        setUrl(url);
+        this.type = "elearning";
+        this.startPage = startPage;
+        this.url = url;
 
+    }
+
+    public String getStartPage() {
+        return startPage;
+    }
+
+    public void setStartPage(String startPage) {
+        this.startPage = startPage;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getMediaId() {
+        return mediaId;
+    }
+
+    public void setMediaId(String mediaId) {
+        this.mediaId = mediaId;
     }
 }
 

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/FileModule.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/FileModule.java
@@ -13,7 +13,7 @@ public class FileModule extends Module {
 
     @JsonCreator
     public FileModule(@JsonProperty("url") String url, @JsonProperty("fileSize") Long fileSize) {
-        setType("file");
+        this.type = "file";
         this.url = url;
         this.fileSize = fileSize;
     }

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/LinkModule.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/LinkModule.java
@@ -16,7 +16,7 @@ public class LinkModule extends Module {
 
     @JsonCreator
     public LinkModule(@JsonProperty("url") URL url) {
-        setType("link");
+        this.type = "link";
         this.url = url;
     }
 

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/Module.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/Module.java
@@ -1,7 +1,9 @@
 package uk.gov.cslearning.catalogue.domain.module;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.Data;
 import org.elasticsearch.common.UUIDs;
 import org.springframework.data.elasticsearch.annotations.Field;
 import uk.gov.cslearning.catalogue.domain.Status;
@@ -20,34 +22,36 @@ import static org.springframework.data.elasticsearch.annotations.FieldType.Date;
         @JsonSubTypes.Type(VideoModule.class),
         @JsonSubTypes.Type(FileModule.class)
 })
+@Data
 public abstract class Module {
 
-    private String id = UUIDs.randomBase64UUID();
+    protected String id = UUIDs.randomBase64UUID();
 
     @NotNull
-    private String title;
+    protected String title;
 
     @NotNull
-    private String description;
+    protected String description;
 
     @NotNull
-    private Long duration;
+    protected Long duration;
 
-    private BigDecimal cost = new BigDecimal(0);
+    protected BigDecimal cost = new BigDecimal(0);
 
-    private boolean optional;
+    protected boolean optional;
 
-    private Status status;
+    protected Status status;
 
-    private boolean associatedLearning;
+    protected boolean associatedLearning;
 
-    private String type;
+    @JsonIgnore
+    protected String type;
 
     @Field(type = Date, format = {}, pattern = "uuuu-MM-dd'T'HH:mm:ss")
-    private LocalDateTime createdTimestamp;
+    protected LocalDateTime createdTimestamp;
 
     @Field(type = Date, format = {}, pattern = "uuuu-MM-dd'T'HH:mm:ss")
-    private LocalDateTime updatedTimestamp;
+    protected LocalDateTime updatedTimestamp;
 
     public Module() {
     }
@@ -62,14 +66,6 @@ public abstract class Module {
         this.type = type;
     }
 
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
     public boolean isOptional() {
         return optional;
     }
@@ -78,76 +74,12 @@ public abstract class Module {
         this.optional = optional;
     }
 
-    public Status getStatus() {
-        return status;
-    }
-
-    public void setStatus(Status status) {
-        this.status = status;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public Long getDuration() {
-        return duration;
-    }
-
-    public void setDuration(Long duration) {
-        this.duration = duration;
-    }
-
-    public BigDecimal getCost() {
-        return cost;
-    }
-
-    public void setCost(BigDecimal cost) {
-        this.cost = cost;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
     public boolean isAssociatedLearning() {
         return associatedLearning;
     }
 
     public void setAssociatedLearning(boolean associatedLearning) {
         this.associatedLearning = associatedLearning;
-    }
-
-    public LocalDateTime getCreatedTimestamp() {
-        return createdTimestamp;
-    }
-
-    public void setCreatedTimestamp(LocalDateTime createdTimestamp) {
-        this.createdTimestamp = createdTimestamp;
-    }
-
-    public LocalDateTime getUpdatedTimestamp() {
-        return updatedTimestamp;
-    }
-
-    public void setUpdatedTimestamp(LocalDateTime updatedTimestamp) {
-        this.updatedTimestamp = updatedTimestamp;
-    }
-
-    public String getType(){
-        return this.type;
-    }
-
-    public void setType(String type){
-        this.type = type;
     }
 
     public String getModuleType(){

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/VideoModule.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/VideoModule.java
@@ -13,7 +13,7 @@ public class VideoModule extends Module {
 
     @JsonCreator
     public VideoModule(@JsonProperty("url") URL url) {
-        setType("video");
+        this.type = "video";
         this.url = url;
     }
 

--- a/src/test/java/uk/gov/cslearning/catalogue/integration/CourseControllerTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/integration/CourseControllerTest.java
@@ -1,35 +1,53 @@
 package uk.gov.cslearning.catalogue.integration;
 
+import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Order;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.cslearning.catalogue.config.DisableBlobStorage;
 import uk.gov.cslearning.catalogue.config.IntegrationTestConfig;
+import uk.gov.cslearning.catalogue.domain.CivilServant.CivilServant;
 import uk.gov.cslearning.catalogue.domain.Course;
+import uk.gov.cslearning.catalogue.domain.Owner.Owner;
 import uk.gov.cslearning.catalogue.domain.Status;
 import uk.gov.cslearning.catalogue.domain.Visibility;
 import uk.gov.cslearning.catalogue.domain.module.ELearningModule;
 import uk.gov.cslearning.catalogue.domain.module.Module;
 import uk.gov.cslearning.catalogue.repository.CourseRepository;
+import uk.gov.cslearning.catalogue.service.RegistryService;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 @RunWith(SpringRunner.class)
 @Import({IntegrationTestConfig.class, DisableBlobStorage.class})
-@AutoConfigureWebTestClient
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = {"spring.main.allow-bean-definition-overriding=true"})
+@AutoConfigureMockMvc
 public class CourseControllerTest extends ElasticContainerBase {
+
+    @MockBean
+    private RegistryService mockRegistryService;
 
     @Autowired
     private CourseRepository repository;
@@ -37,10 +55,13 @@ public class CourseControllerTest extends ElasticContainerBase {
     private ArrayList<String> courseIds = new ArrayList<>();
 
     @Autowired
-    private WebTestClient webTestClient;
+    private MockMvc mvc;
 
     @Before
     public void before() {
+        // Any endpoint annotated with @PreAuthorize will call CsrsService to get the current civil servant.
+        // We should mock this call out with wiremock but until then let's just mock the method out
+        when(mockRegistryService.getCurrentCivilServant()).thenReturn(new CivilServant());
         loadCourses();
     }
 
@@ -51,6 +72,7 @@ public class CourseControllerTest extends ElasticContainerBase {
 
     private void loadCourses() {
         Course course1 = new Course("Course 1", "Course 1 short description", "Course 1 long description", Visibility.PUBLIC);
+        course1.setOwner(new Owner());
         course1.setStatus(Status.PUBLISHED);
 
         Module elearningModule = new ELearningModule("http://startPage", "http://url.com");
@@ -64,68 +86,100 @@ public class CourseControllerTest extends ElasticContainerBase {
         course2.setStatus(Status.PUBLISHED);
 
         course2.setModules(Arrays.asList(elearningModule));
+        course2.setOwner(new Owner());
 
         List<Course> courses = Arrays.asList(course1, course2);
 
         repository.saveAll(courses).forEach(c -> courseIds.add(c.getId()));
+
     }
 
     @Test
-    public void testGetCourses() {
-        webTestClient.get()
-                .uri("/courses")
-                .exchange()
-                .expectStatus()
-                .is2xxSuccessful()
-                .expectBody()
-                .consumeWith(System.out::println)
-                .jsonPath("$.totalResults").isEqualTo(2)
-                .jsonPath("$.results[0].title").isEqualTo("Course 1")
-                .jsonPath("$.results[0].shortDescription").isEqualTo("Course 1 short description")
-                .jsonPath("$.results[0].description").isEqualTo("Course 1 long description")
-                .jsonPath("$.results[0].status").isEqualTo("Published")
-                .jsonPath("$.results[1].title").isEqualTo("Course 2")
-                .jsonPath("$.results[1].shortDescription").isEqualTo("Course 2 short description")
-                .jsonPath("$.results[1].description").isEqualTo("Course 2 long description")
-                .jsonPath("$.results[1].status").isEqualTo("Published")
-                .jsonPath("$.results[1].modules[0].title").isEqualTo("ELearning module")
-                .jsonPath("$.results[1].modules[0].description").isEqualTo("An ELearning module")
-                .jsonPath("$.results[1].modules[0].cost").isEqualTo(100)
-                .jsonPath("$.results[1].modules[0].duration").isEqualTo(100)
-                .jsonPath("$.results[1].modules[0].optional").isEqualTo(false);
+    @Order(1)
+    public void testGetCourses() throws Exception {
+
+        mvc.perform(get("/courses")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.results[0].title").value("Course 1"))
+                .andExpect(jsonPath("$.results[0].shortDescription").value("Course 1 short description"))
+                .andExpect(jsonPath("$.results[0].description").value("Course 1 long description"))
+                .andExpect(jsonPath("$.results[0].status").value("Published"))
+                .andExpect(jsonPath("$.results[1].title").value("Course 2"))
+                .andExpect(jsonPath("$.results[1].shortDescription").value("Course 2 short description"))
+                .andExpect(jsonPath("$.results[1].description").value("Course 2 long description"))
+                .andExpect(jsonPath("$.results[1].status").value("Published"))
+                .andExpect(jsonPath("$.results[1].modules[0].title").value("ELearning module"))
+                .andExpect(jsonPath("$.results[1].modules[0].description").value("An ELearning module"))
+                .andExpect(jsonPath("$.results[1].modules[0].cost").value(100))
+                .andExpect(jsonPath("$.results[1].modules[0].type").value("elearning"))
+                .andExpect(jsonPath("$.results[1].modules[0].moduleType").value("elearning"))
+                .andExpect(jsonPath("$.results[1].modules[0].duration").value(100))
+                .andExpect(jsonPath("$.results[1].modules[0].optional").value(false));
     }
 
     @Test
-    public void testGetCoursesWithPagination() {
-        webTestClient.get()
-                .uri("/courses?size=1&page=0")
-                .exchange()
-                .expectStatus()
-                .is2xxSuccessful()
-                .expectBody()
-                .consumeWith(System.out::println)
-                .jsonPath("$.totalResults").isEqualTo(2)
-                .jsonPath("$.results[0].title").isEqualTo("Course 1")
-                .jsonPath("$.results[0].shortDescription").isEqualTo("Course 1 short description")
-                .jsonPath("$.results[0].description").isEqualTo("Course 1 long description")
-                .jsonPath("$.results[0].status").isEqualTo("Published");
+    @Order(2)
+    public void testGetCoursesWithPagination() throws Exception {
 
-        webTestClient.get()
-                .uri("/courses?size=1&page=1")
-                .exchange()
-                .expectStatus()
-                .is2xxSuccessful()
-                .expectBody()
-                .consumeWith(System.out::println)
-                .jsonPath("$.results[0].title").isEqualTo("Course 2")
-                .jsonPath("$.results[0].shortDescription").isEqualTo("Course 2 short description")
-                .jsonPath("$.results[0].description").isEqualTo("Course 2 long description")
-                .jsonPath("$.results[0].status").isEqualTo("Published")
-                .jsonPath("$.results[0].modules[0].title").isEqualTo("ELearning module")
-                .jsonPath("$.results[0].modules[0].description").isEqualTo("An ELearning module")
-                .jsonPath("$.results[0].modules[0].cost").isEqualTo(100)
-                .jsonPath("$.results[0].modules[0].duration").isEqualTo(100)
-                .jsonPath("$.results[0].modules[0].optional").isEqualTo(false);
+        mvc.perform(get("/courses?size=1&page=0")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalResults").value(2))
+                .andExpect(jsonPath("$.results[0].title").value("Course 1"))
+                .andExpect(jsonPath("$.results[0].shortDescription").value("Course 1 short description"))
+                .andExpect(jsonPath("$.results[0].description").value("Course 1 long description"))
+                .andExpect(jsonPath("$.results[0].status").value("Published"));
+
+        mvc.perform(get("/courses?size=1&page=1")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.results[0].title").value("Course 2"))
+                .andExpect(jsonPath("$.results[0].shortDescription").value("Course 2 short description"))
+                .andExpect(jsonPath("$.results[0].description").value("Course 2 long description"))
+                .andExpect(jsonPath("$.results[0].status").value("Published"))
+                .andExpect(jsonPath("$.results[0].modules[0].title").value("ELearning module"))
+                .andExpect(jsonPath("$.results[0].modules[0].description").value("An ELearning module"))
+                .andExpect(jsonPath("$.results[0].modules[0].cost").value(100))
+                .andExpect(jsonPath("$.results[0].modules[0].duration").value(100))
+                .andExpect(jsonPath("$.results[0].modules[0].type").value("elearning"))
+                .andExpect(jsonPath("$.results[0].modules[0].moduleType").value("elearning"))
+                .andExpect(jsonPath("$.results[0].modules[0].optional").value(false));
+
+    }
+
+    @Test
+    @Order(3)
+    @WithMockUser(value = "spring", authorities = {"CSL_AUTHOR"})
+    public void testCreateModule() throws Exception {
+
+        String json = new JSONObject()
+                .put("url", "http://url.com")
+                .put("title", "Link module")
+                .put("description", "A link module")
+                .put("duration",  100)
+                .put("cost",  0)
+                .put("optional",  false)
+                .put("associatedLearning",  false)
+                .put("type", "link")
+                .toString();
+
+        mvc.perform(post(String.format("/courses/%s/modules", courseIds.get(0)))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isCreated());
+
+        mvc.perform(get(String.format("/courses/%s", courseIds.get(0))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.modules[0].title").value("Link module"))
+                .andExpect(jsonPath("$.modules[0].description").value("A link module"))
+                .andExpect(jsonPath("$.modules[0].cost").value(0))
+                .andExpect(jsonPath("$.modules[0].duration").value(100))
+                .andExpect(jsonPath("$.modules[0].moduleType").value("link"))
+                .andExpect(jsonPath("$.modules[0].type").value("link"))
+                .andExpect(jsonPath("$.modules[0].optional").value(false));
+
     }
 
 }


### PR DESCRIPTION
- JsonIgnore the type field in the Module class. This is because the `@JsonTypeInfo` annotation provides its own `type` field. This was causing type to appear twice when fetching modules from the API
- Refactor integration tests to use `MockMvc`
- Add new test for creating a module. This is to ensure that the code changes did not break the previous bugfix for setting the module type correctly