### PR TITLE
LC-3410: Fix SCORM upload bug

### DIFF
--- a/src/main/java/uk/gov/cslearning/catalogue/service/util/InputStreamUtil.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/util/InputStreamUtil.java
@@ -1,0 +1,21 @@
+package uk.gov.cslearning.catalogue.service.util;
+
+import java.io.*;
+
+public class InputStreamUtil {
+    public static File saveInputStreamAsTempFile(InputStream inputStream) throws IOException {
+        File tempInputStreamFile = File.createTempFile("tempinputstream", ".tmp");
+        tempInputStreamFile.deleteOnExit();
+        FileOutputStream fileOutputStream = new FileOutputStream(tempInputStreamFile);
+        byte[] buffer = new byte[1024];
+        int bytesRead;
+        while ((bytesRead = inputStream.read(buffer)) != -1) {
+            fileOutputStream.write(buffer, 0, bytesRead);
+        }
+        return tempInputStreamFile;
+    }
+
+    public static InputStream getInputStreamFromFile(File file) throws IOException {
+        return new FileInputStream(file);
+    }
+}


### PR DESCRIPTION
This change fixes a bug that threw an "out of memory" error when uploading SCORM files with large containing files:

* Introduces the `InputStreamUtil` class which saves an `InputStream` as a temporary file and retrieves a file back as an `InputStream`
* Uses the `InputStreamUtil` in `UploadableFileFactory` to be used in multiple instances.