### PR TITLE
LC 3429 cancel event

### DIFF
--- a/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
@@ -346,10 +346,11 @@ public class CourseController {
 
 
     @GetMapping("/{courseId}")
-    public ResponseEntity<Course> get(@PathVariable("courseId") String courseId) {
+    public ResponseEntity<Course> get(@PathVariable("courseId") String courseId,
+                                      @RequestParam(value = "courseId", required = false, defaultValue = "false") boolean includeAvailability) {
         LOGGER.debug("Getting course with ID {}", courseId);
 
-        Optional<Course> result = courseService.findById(courseId);
+        Optional<Course> result = courseService.findById(courseId, includeAvailability);
 
         return result
                 .map(course -> new ResponseEntity<>(course, OK))

--- a/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
@@ -347,7 +347,7 @@ public class CourseController {
 
     @GetMapping("/{courseId}")
     public ResponseEntity<Course> get(@PathVariable("courseId") String courseId,
-                                      @RequestParam(value = "courseId", required = false, defaultValue = "false") boolean includeAvailability) {
+                                      @RequestParam(value = "includeAvailability", required = false, defaultValue = "false") boolean includeAvailability) {
         LOGGER.debug("Getting course with ID {}", courseId);
 
         Optional<Course> result = courseService.findById(courseId, includeAvailability);

--- a/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
@@ -474,7 +474,8 @@ public class CourseController {
                 FaceToFaceModule faceToFaceModule = (FaceToFaceModule) module;
 
                 Event event = faceToFaceModule.getEventById(eventId);
-
+                event.setStatus(newEvent.getStatus());
+                event.setCancellationReason(newEvent.getCancellationReason());
                 event.setDateRanges(newEvent.getDateRanges());
                 event.setJoiningInstructions(newEvent.getJoiningInstructions());
 

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/CancellationReason.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/CancellationReason.java
@@ -17,7 +17,7 @@ public enum CancellationReason {
     @JsonCreator
     public static CancellationReason forValue(String value) {
         return Arrays.stream(CancellationReason.values())
-        .filter(v -> v.value.equalsIgnoreCase(value))
+        .filter(v -> v.value.equalsIgnoreCase(value) || v.toString().equalsIgnoreCase(value))
         .findAny()
         .orElseThrow(() -> new Error("Error, unknown status: " + value));
     }

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/module/Event.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/module/Event.java
@@ -1,12 +1,14 @@
 package uk.gov.cslearning.catalogue.domain.module;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.elasticsearch.common.UUIDs;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static java.util.Collections.unmodifiableList;
-
+@Data
+@NoArgsConstructor
 public class Event {
 
     private String id = UUIDs.randomBase64UUID();
@@ -21,57 +23,4 @@ public class Event {
 
     private CancellationReason cancellationReason;
 
-    public Event() {
-    }
-
-    public String getJoiningInstructions() {
-        return joiningInstructions;
-    }
-
-    public void setJoiningInstructions(String joiningInstructions) {
-        this.joiningInstructions = joiningInstructions;
-    }
-
-    public List<DateRange> getDateRanges() {
-        return unmodifiableList(dateRanges);
-    }
-
-    public void setDateRanges(List<DateRange> dateRanges) {
-        this.dateRanges.clear();
-        if (dateRanges != null) {
-            this.dateRanges.addAll(dateRanges);
-        }
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public Venue getVenue() {
-        return venue;
-    }
-
-    public void setVenue(Venue venue) {
-        this.venue = venue;
-    }
-
-    public EventStatus getStatus() {
-        return status;
-    }
-
-    public void setStatus(EventStatus status) {
-        this.status = status;
-    }
-
-    public CancellationReason getCancellationReason() {
-        return cancellationReason;
-    }
-
-    public void setCancellationReason(CancellationReason cancellationReason) {
-        this.cancellationReason = cancellationReason;
-    }
 }

--- a/src/main/java/uk/gov/cslearning/catalogue/evaluators/CustomPermissionEvaluator.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/evaluators/CustomPermissionEvaluator.java
@@ -50,8 +50,6 @@ public class CustomPermissionEvaluator implements PermissionEvaluator {
     }
 
     private boolean hasScope(Authentication auth, String id) {
-        CivilServant civilServant = registryService.getCurrentCivilServant();
-        civilServant.setSupplier(authoritiesService.getSupplier(auth));
 
         Course course = courseService.findById(id).orElseThrow((Supplier<IllegalStateException>) () -> {
             throw new IllegalStateException(
@@ -62,6 +60,8 @@ public class CustomPermissionEvaluator implements PermissionEvaluator {
             return false;
         }
 
+        CivilServant civilServant = null;
+
         for (GrantedAuthority grantedAuth : auth.getAuthorities()) {
             LOGGER.info("User has authority: {}", grantedAuth.getAuthority());
 
@@ -71,11 +71,18 @@ public class CustomPermissionEvaluator implements PermissionEvaluator {
             if (grantedAuth.getAuthority().equals(Roles.LEARNING_MANAGER)) {
                 return true;
             }
-            if (grantedAuth.getAuthority().equals(Roles.ORGANISATION_AUTHOR) && authoritiesService.isOrganisationalUnitCodeEqual(civilServant, course.getOwner())) {
-                return true;
+
+            if (grantedAuth.getAuthority().equals(Roles.ORGANISATION_AUTHOR)) {
+                if (civilServant == null) civilServant = registryService.getCurrentCivilServant();
+                if (authoritiesService.isOrganisationalUnitCodeEqual(civilServant, course.getOwner())) {
+                    return true;
+                }
             }
-            if (grantedAuth.getAuthority().equals(Roles.PROFESSION_AUTHOR) && authoritiesService.isProfessionIdEqual(civilServant, course.getOwner())) {
-                return true;
+            if (grantedAuth.getAuthority().equals(Roles.PROFESSION_AUTHOR)) {
+                if (civilServant == null)  civilServant = registryService.getCurrentCivilServant();
+                if (authoritiesService.isProfessionIdEqual(civilServant, course.getOwner())) {
+                    return true;
+                }
             }
             if ((grantedAuth.getAuthority().equals(Roles.KPMG_SUPPLIER_AUTHOR)
                     || grantedAuth.getAuthority().equals(Roles.KORNFERRY_SUPPLIER_AUTHOR)

--- a/src/main/java/uk/gov/cslearning/catalogue/service/CourseService.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/CourseService.java
@@ -91,12 +91,26 @@ public class CourseService {
     }
 
     public Optional<Course> findById(String courseId) {
+        return this.findById(courseId, false);
+    }
+
+    public Optional<Course> findById(String courseId, boolean includeAvailability) {
         return courseRepository.findById(courseId)
-                .map(this::getCourseEventsAvailability);
+                .map(c -> {
+                    if (includeAvailability) {
+                        return getCourseEventsAvailability(c);
+                    } else {
+                        return c;
+                    }
+                });
     }
 
     public Course getCourseById(String courseId) throws IllegalStateException {
-        return findById(courseId)
+        return this.getCourseById(courseId, false);
+    }
+
+    public Course getCourseById(String courseId, boolean includeAvailability) throws IllegalStateException {
+        return findById(courseId, includeAvailability)
                 .orElseThrow((Supplier<IllegalStateException>) () -> {
                     throw new IllegalStateException(
                             String.format("Unable to find course. Course does not exist: %s", courseId));

--- a/src/main/java/uk/gov/cslearning/catalogue/service/EventService.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/EventService.java
@@ -126,7 +126,6 @@ public class EventService {
             uk.gov.cslearning.catalogue.service.record.model.Event lrEvent = lrEventMap.get(e.getId());
             if (lrEvent != null) {
                 e.getVenue().setAvailability(e.getVenue().getCapacity() - lrEvent.getActiveBookingCount());
-                e.setStatus(EventStatus.forValue(lrEvent.getStatus()));
             }
         });
         return events;

--- a/src/main/java/uk/gov/cslearning/catalogue/service/EventService.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/service/EventService.java
@@ -56,6 +56,7 @@ public class EventService {
             newEvents.add(e);
         }
 
+        event.setStatus(EventStatus.ACTIVE);
         newEvents.add(event);
 
         module.setEvents(newEvents);

--- a/src/test/java/uk/gov/cslearning/catalogue/api/CourseControllerTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/api/CourseControllerTest.java
@@ -509,7 +509,7 @@ public class CourseControllerTest {
 
         Course course = createCourse();
 
-        when(courseService.findById("1"))
+        when(courseService.findById("1", false))
                 .thenReturn(Optional.of(course));
 
         mockMvc.perform(

--- a/src/test/java/uk/gov/cslearning/catalogue/evaluators/CustomPermissionEvaluatorTest.java
+++ b/src/test/java/uk/gov/cslearning/catalogue/evaluators/CustomPermissionEvaluatorTest.java
@@ -89,9 +89,6 @@ public class CustomPermissionEvaluatorTest {
 
     @Test(expected = IllegalStateException.class)
     public void shouldThrowExceptionIfCourseIsNotPresent() {
-        CivilServant civilServant = new CivilServant();
-
-        when(registryService.getCurrentCivilServant()).thenReturn(civilServant);
         when(courseService.findById(any())).thenReturn(Optional.empty());
 
         customPermissionEvaluator.hasPermission(authentication, COURSE_ID, WRITE_PERMISSION);
@@ -101,10 +98,6 @@ public class CustomPermissionEvaluatorTest {
     @Test
     public void shouldReturnFalseIfCourseHasNoOwner() {
         Course course = new Course();
-
-        CivilServant civilServant = new CivilServant();
-
-        when(registryService.getCurrentCivilServant()).thenReturn(civilServant);
         when(courseService.findById(any())).thenReturn(Optional.of(course));
 
         boolean hasPermission = customPermissionEvaluator.hasPermission(authentication, COURSE_ID, WRITE_PERMISSION);
@@ -118,9 +111,6 @@ public class CustomPermissionEvaluatorTest {
         Owner owner = new Owner();
         course.setOwner(owner);
 
-        CivilServant civilServant = new CivilServant();
-
-        when(registryService.getCurrentCivilServant()).thenReturn(civilServant);
         when(courseService.findById(any())).thenReturn(Optional.of(course));
 
         boolean hasPermission = customPermissionEvaluator.hasPermission(authentication, COURSE_ID, WRITE_PERMISSION);
@@ -131,8 +121,6 @@ public class CustomPermissionEvaluatorTest {
 
     @Test
     public void shouldReturnTrueIfUserHasCslAuthor() {
-        CivilServant civilServant = new CivilServant();
-
         Course course = new Course();
         Owner owner = new Owner();
         course.setOwner(owner);
@@ -141,7 +129,6 @@ public class CustomPermissionEvaluatorTest {
         authorities.add(new SimpleGrantedAuthority(Roles.CSL_AUTHOR));
 
         doReturn(authorities).when(authentication).getAuthorities();
-        when(registryService.getCurrentCivilServant()).thenReturn(civilServant);
         when(courseService.findById(any())).thenReturn(Optional.of(course));
 
         boolean hasPermission = customPermissionEvaluator.hasPermission(authentication, COURSE_ID, WRITE_PERMISSION);
@@ -151,7 +138,6 @@ public class CustomPermissionEvaluatorTest {
 
     @Test
     public void shouldReturnTrueIfUserHasLearningManager() {
-        CivilServant civilServant = new CivilServant();
 
         Course course = new Course();
         Owner owner = new Owner();
@@ -161,7 +147,6 @@ public class CustomPermissionEvaluatorTest {
         authorities.add(new SimpleGrantedAuthority(Roles.LEARNING_MANAGER));
 
         doReturn(authorities).when(authentication).getAuthorities();
-        when(registryService.getCurrentCivilServant()).thenReturn(civilServant);
         when(courseService.findById(any())).thenReturn(Optional.of(course));
 
         boolean hasPermission = customPermissionEvaluator.hasPermission(authentication, COURSE_ID, WRITE_PERMISSION);


### PR DESCRIPTION
- Correctly update an event using PATCH. This allows events to be cancelled within the ES metadata
- Refactor `CustomPermissionEvaluator` to only fetch the civil servant when comparing profession/organisation roles
- `includeAvailability` flag on `GET /courses/{courseId}`. This prevents unnecessary calls to the learner record when the availability of an event is not required