### PR TITLE
LC-3669: Delete draft courses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ out
 .project
 .settings/*
 .ash_history
+.DS_Store

--- a/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/api/CourseController.java
@@ -24,6 +24,7 @@ import uk.gov.cslearning.catalogue.domain.module.Audience;
 import uk.gov.cslearning.catalogue.domain.module.Event;
 import uk.gov.cslearning.catalogue.domain.module.FaceToFaceModule;
 import uk.gov.cslearning.catalogue.domain.module.Module;
+import uk.gov.cslearning.catalogue.exception.CourseCannotByDeletedException;
 import uk.gov.cslearning.catalogue.exception.ResourceNotFoundException;
 import uk.gov.cslearning.catalogue.mapping.DaysMapper;
 import uk.gov.cslearning.catalogue.repository.CourseRepository;
@@ -363,6 +364,23 @@ public class CourseController {
         courseService.updateCourse(courseId, newCourse);
         return ResponseEntity.ok(null);
     }
+
+    @DeleteMapping(path = "/{courseId}")
+    @PreAuthorize("(hasAnyAuthority(T(uk.gov.cslearning.catalogue.domain.Roles).LEARNING_DELETE, T(uk.gov.cslearning.catalogue.domain.Roles).LEARNING_MANAGER, T(uk.gov.cslearning.catalogue.domain.Roles).CSL_AUTHOR))")
+    public ResponseEntity<Void> delete(@PathVariable("courseId") String courseId){
+        try{
+            LOGGER.info("Deleting course with ID {} ", courseId);
+            courseService.deleteCourseById(courseId);
+            LOGGER.info("Course with ID {} deleted successfully.", courseId);
+            return ResponseEntity.ok(null);
+        }
+        catch (CourseCannotByDeletedException e){
+            LOGGER.error("Exception thrown while trying to delete course with ID {}: {}", courseId, e.getMessage());
+            return ResponseEntity.status(CONFLICT).build();
+        }
+
+    }
+
 
     @PostMapping("/{courseId}/modules")
     @PreAuthorize("(hasPermission(#courseId, 'write') and hasAnyAuthority(T(uk.gov.cslearning.catalogue.domain.Roles).LEARNING_CREATE, T(uk.gov.cslearning.catalogue.domain.Roles).LEARNING_MANAGER, T(uk.gov.cslearning.catalogue.domain.Roles).CSL_AUTHOR))")

--- a/src/main/java/uk/gov/cslearning/catalogue/domain/Course.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/domain/Course.java
@@ -72,6 +72,8 @@ public class Course {
 
     private BigDecimal cost = new BigDecimal(0);
 
+    private Boolean hasBeenPublished;
+
     public Course() {
     }
 

--- a/src/main/java/uk/gov/cslearning/catalogue/exception/CourseCannotByDeletedException.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/exception/CourseCannotByDeletedException.java
@@ -1,0 +1,7 @@
+package uk.gov.cslearning.catalogue.exception;
+
+public class CourseCannotByDeletedException extends RuntimeException{
+    public CourseCannotByDeletedException(){
+        super("A course cannot be deleted if it has been previously published");
+    }
+}

--- a/src/main/java/uk/gov/cslearning/catalogue/repository/CourseRepository.java
+++ b/src/main/java/uk/gov/cslearning/catalogue/repository/CourseRepository.java
@@ -92,4 +92,5 @@ public interface CourseRepository extends ElasticsearchRepository<Course, String
 
     Page<Course> findAllBySupplier(String supplier, Pageable pageable);
 
+    void deleteCourseById(String id);
 }


### PR DESCRIPTION
This change:

* Creates a new `DELETE` endpoint for deleting Draft courses.
* Updates the `Course` model to include a new `hasBeenPublished` flag, which is set to `true` when a course is published.